### PR TITLE
feat(openapi): implement OpenAPI adapter with RouteTable integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [{ name = "Oaklight", email = "pding.sam@gmail.com" }]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/toolregistry_server/auth/__init__.py
+++ b/src/toolregistry_server/auth/__init__.py
@@ -7,18 +7,21 @@ ToolRegistry server endpoints.
 Main Components:
     - BearerTokenAuth: Bearer token authentication for FastAPI
     - verify_token: Token verification utility
+    - create_bearer_dependency: Create a FastAPI dependency for Bearer auth
 
 Example:
-    >>> from toolregistry_server.auth import BearerTokenAuth
+    >>> from toolregistry_server.auth import BearerTokenAuth, create_bearer_dependency
     >>>
     >>> auth = BearerTokenAuth(tokens=["secret-token"])
     >>> # Use with FastAPI dependency injection
+    >>> dependency = create_bearer_dependency(auth)
 """
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
+    from typing import Any
 
 
 class BearerTokenAuth:
@@ -56,6 +59,15 @@ class BearerTokenAuth:
             True if at least one token is configured.
         """
         return self._enabled
+
+    @property
+    def tokens(self) -> set[str]:
+        """Get the set of valid tokens.
+
+        Returns:
+            Set of valid tokens.
+        """
+        return self._tokens.copy()
 
     def verify(self, token: str) -> bool:
         """Verify a token.
@@ -102,7 +114,79 @@ def verify_token(token: str, valid_tokens: "Sequence[str]") -> bool:
     return token in valid_tokens
 
 
+def create_bearer_dependency(auth: BearerTokenAuth) -> "Callable[..., Any]":
+    """Create a FastAPI dependency for Bearer token authentication.
+
+    This function creates a dependency that can be used with FastAPI's
+    dependency injection system to protect endpoints with Bearer token
+    authentication.
+
+    Args:
+        auth: The BearerTokenAuth instance to use for verification.
+
+    Returns:
+        A FastAPI dependency function.
+
+    Raises:
+        ImportError: If FastAPI is not installed.
+
+    Example:
+        >>> from fastapi import FastAPI, Depends
+        >>> from toolregistry_server.auth import BearerTokenAuth, create_bearer_dependency
+        >>>
+        >>> auth = BearerTokenAuth(tokens=["secret-token"])
+        >>> dependency = create_bearer_dependency(auth)
+        >>>
+        >>> app = FastAPI(dependencies=[Depends(dependency)])
+    """
+    try:
+        from typing import Annotated
+
+        from fastapi import Depends, HTTPException, status
+        from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+    except ImportError as e:
+        raise ImportError(
+            "FastAPI is required for authentication dependencies. "
+            "Install with: pip install toolregistry-server[openapi]"
+        ) from e
+
+    security = HTTPBearer()
+
+    async def verify_bearer_token(
+        credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    ) -> str:
+        """Verify Bearer token from Authorization header.
+
+        Args:
+            credentials: HTTP Bearer credentials from the Authorization header
+
+        Returns:
+            The verified token string
+
+        Raises:
+            HTTPException: If token is invalid or missing when required
+        """
+        # If no tokens configured, disable verification
+        if not auth.enabled:
+            return ""
+
+        # Extract token from credentials
+        token = credentials.credentials
+
+        if not auth.verify(token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        return token
+
+    return verify_bearer_token
+
+
 __all__ = [
     "BearerTokenAuth",
+    "create_bearer_dependency",
     "verify_token",
 ]

--- a/src/toolregistry_server/openapi/__init__.py
+++ b/src/toolregistry_server/openapi/__init__.py
@@ -7,6 +7,7 @@ RESTful HTTP endpoints using FastAPI.
 Main Components:
     - create_openapi_app: Create a FastAPI application from a RouteTable
     - route_table_to_router: Convert a RouteTable to a FastAPI router
+    - setup_dynamic_openapi: Configure dynamic OpenAPI schema generation
 
 Example:
     >>> from toolregistry import ToolRegistry
@@ -22,10 +23,12 @@ Note:
     pip install toolregistry-server[openapi]
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from fastapi import APIRouter, FastAPI
+    from collections.abc import Sequence
+
+    from fastapi import FastAPI
 
     from ..route_table import RouteTable
 
@@ -35,6 +38,7 @@ def create_openapi_app(
     title: str = "ToolRegistry Server",
     version: str = "1.0.0",
     description: str = "OpenAPI server for ToolRegistry tools",
+    dependencies: "Sequence[Any] | None" = None,
 ) -> "FastAPI":
     """Create a FastAPI application from a RouteTable.
 
@@ -43,6 +47,7 @@ def create_openapi_app(
         title: API title for OpenAPI schema.
         version: API version for OpenAPI schema.
         description: API description for OpenAPI schema.
+        dependencies: Optional list of global dependencies (e.g., authentication).
 
     Returns:
         A configured FastAPI application.
@@ -58,49 +63,33 @@ def create_openapi_app(
             "Install with: pip install toolregistry-server[openapi]"
         ) from e
 
-    app = FastAPI(title=title, version=version, description=description)
+    from .adapter import route_table_to_router, setup_dynamic_openapi
+
+    # Create app with optional global dependencies
+    if dependencies:
+        app = FastAPI(
+            title=title,
+            version=version,
+            description=description,
+            dependencies=list(dependencies),
+        )
+    else:
+        app = FastAPI(
+            title=title,
+            version=version,
+            description=description,
+        )
 
     # Add routes from route table
     router = route_table_to_router(route_table)
     app.include_router(router)
 
+    # Setup dynamic OpenAPI schema that filters disabled tools
+    setup_dynamic_openapi(app, route_table)
+
     return app
-
-
-def route_table_to_router(
-    route_table: "RouteTable",
-    prefix: str = "/tools",
-) -> "APIRouter":
-    """Convert a RouteTable into a FastAPI router.
-
-    Args:
-        route_table: The RouteTable to convert.
-        prefix: URL prefix for all routes.
-
-    Returns:
-        A FastAPI APIRouter with all tool routes.
-
-    Raises:
-        ImportError: If FastAPI is not installed.
-    """
-    try:
-        from fastapi import APIRouter
-    except ImportError as e:
-        raise ImportError(
-            "FastAPI is required for OpenAPI support. "
-            "Install with: pip install toolregistry-server[openapi]"
-        ) from e
-
-    router = APIRouter(prefix=prefix)
-
-    # TODO: Implement route generation from RouteTable
-    # This is a skeleton implementation - full implementation will be
-    # migrated from toolregistry-hub's autoroute.py
-
-    return router
 
 
 __all__ = [
     "create_openapi_app",
-    "route_table_to_router",
 ]

--- a/src/toolregistry_server/openapi/adapter.py
+++ b/src/toolregistry_server/openapi/adapter.py
@@ -1,0 +1,333 @@
+"""Automatic route generation from a RouteTable.
+
+Converts a :class:`~toolregistry_server.RouteTable` into a FastAPI
+:class:`~fastapi.APIRouter` by introspecting each registered route
+and dynamically creating Pydantic request models and route handlers.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field, create_model
+
+from ..route_table import RouteEntry, RouteTable
+
+# ---------------------------------------------------------------------------
+# JSON Schema type → Python type mapping
+# ---------------------------------------------------------------------------
+
+_JSON_TYPE_MAP: dict[str, type] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve a single field schema to a Python type
+# ---------------------------------------------------------------------------
+
+
+def _resolve_type(field_schema: dict[str, Any]) -> type:
+    """Resolve a JSON Schema field description to a Python type.
+
+    Handles basic types, ``array`` with ``items``, nested ``object`` with
+    ``properties`` (recursively creates a Pydantic model), ``enum`` via
+    ``Literal``, and falls back to ``Any`` for unknown schemas.
+
+    Args:
+        field_schema: A single-field JSON Schema dict (e.g.
+            ``{"type": "string"}`` or ``{"type": "array", "items": {...}}``).
+
+    Returns:
+        The resolved Python type suitable for use in a Pydantic model field.
+    """
+    # Handle enum → Literal
+    if "enum" in field_schema:
+        from typing import Literal  # noqa: UP035 – needed at runtime
+
+        values = tuple(field_schema["enum"])
+        return Literal[values]  # ty: ignore[invalid-type-form]
+
+    json_type = field_schema.get("type")
+
+    if json_type == "array":
+        items_schema = field_schema.get("items")
+        if items_schema:
+            inner = _resolve_type(items_schema)
+            return list[inner]  # ty: ignore[invalid-type-form]
+        return list
+
+    if json_type == "object" and "properties" in field_schema:
+        # Recursively build a nested Pydantic model
+        return _schema_to_pydantic("NestedModel", field_schema)
+
+    if json_type is not None:
+        return _JSON_TYPE_MAP.get(json_type, Any)
+
+    # anyOf / oneOf patterns (e.g. Optional fields from toolregistry)
+    any_of = field_schema.get("anyOf") or field_schema.get("oneOf")
+    if any_of:
+        non_null = [s for s in any_of if s.get("type") != "null"]
+        if len(non_null) == 1:
+            return _resolve_type(non_null[0])
+
+    return Any
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema → Pydantic model
+# ---------------------------------------------------------------------------
+
+
+def _schema_to_pydantic(name: str, schema: dict[str, Any]) -> type[BaseModel]:
+    """Convert a JSON Schema ``object`` definition into a dynamic Pydantic model.
+
+    Args:
+        name: The class name for the generated model.
+        schema: A JSON Schema dict with ``properties`` (and optionally
+            ``required``).
+
+    Returns:
+        A dynamically created :class:`pydantic.BaseModel` subclass whose
+        fields mirror the schema properties.
+    """
+    properties: dict[str, Any] = schema.get("properties", {})
+    if not properties:
+        # Return an empty model when there are no properties
+        return create_model(name)
+
+    required_fields: list[str] = schema.get("required", [])
+    field_definitions: dict[str, tuple[type, Any]] = {}
+
+    for field_name, field_schema in properties.items():
+        py_type = _resolve_type(field_schema)
+        description = field_schema.get("description")
+
+        is_required = field_name in required_fields
+        default_value = field_schema.get("default", ... if is_required else None)
+
+        field_kwargs: dict[str, Any] = {}
+        if description:
+            field_kwargs["description"] = description
+
+        if default_value is ...:
+            field_definitions[field_name] = (py_type, Field(**field_kwargs))
+        else:
+            field_definitions[field_name] = (
+                py_type,
+                Field(default=default_value, **field_kwargs),
+            )
+
+    return create_model(name, **field_definitions)  # ty: ignore[no-matching-overload]
+
+
+# ---------------------------------------------------------------------------
+# Route generation
+# ---------------------------------------------------------------------------
+
+
+def _add_route_from_entry(
+    router: "APIRouter",  # noqa: F821
+    route: RouteEntry,
+    route_table: RouteTable,
+) -> None:
+    """Create and register a POST route for a single RouteEntry.
+
+    The route path is taken from the RouteEntry.path attribute.
+
+    For async tools the handler is an ``async def``; for sync tools a plain
+    ``def`` is used. A closure is used to correctly capture the loop
+    variable.
+
+    Each endpoint checks at request time whether the tool is still enabled
+    via ``route_table.get_route()``. If the tool has been disabled at runtime,
+    the endpoint returns HTTP 503 Service Unavailable.
+
+    Args:
+        router: The :class:`~fastapi.APIRouter` to add the route to.
+        route: The :class:`~toolregistry_server.RouteEntry` to expose.
+        route_table: The :class:`~toolregistry_server.RouteTable` used for
+            runtime enable/disable checks.
+    """
+    from fastapi import HTTPException
+
+    # Determine request model from parameters schema
+    model_name = f"{route.tool_name.replace('-', '_').title().replace('_', '')}Request"
+    request_model = _schema_to_pydantic(model_name, route.parameters_schema)
+
+    summary = (route.description or "")[:120]
+    # Use the top-level segment of the namespace as the tag for grouping
+    # e.g. "web/brave_search" → tag "web", "calculator" → tag "calculator"
+    namespace = route.namespace
+    if namespace:
+        tag = namespace.split("/")[0]
+        tags = [tag]
+    else:
+        tags = []
+
+    # Capture tool_name as a string to avoid closure-over-loop-variable issues.
+    tool_name = route.tool_name
+    handler = route.handler
+
+    # Use factory functions to capture route, RequestModel, route_table, and
+    # tool_name per iteration via closure.
+
+    if route.is_async:
+
+        def _make_async_endpoint(
+            h: Any = handler,
+            M: type[BaseModel] = request_model,
+            rt: RouteTable = route_table,
+            tname: str = tool_name,
+        ):
+            async def _endpoint(data: M) -> Any:  # ty: ignore[invalid-type-form]
+                current_route = rt.get_route(tname)
+                if current_route is None or not current_route.enabled:
+                    raise HTTPException(
+                        status_code=503,
+                        detail=f"Tool '{tname}' is currently disabled",
+                    )
+                return await h(**data.model_dump())
+
+            return _endpoint
+
+        router.add_api_route(
+            route.path,
+            _make_async_endpoint(),
+            methods=["POST"],
+            operation_id=route.tool_name,
+            summary=summary,
+            tags=tags,  # ty: ignore[invalid-argument-type]
+        )
+    else:
+
+        def _make_sync_endpoint(
+            h: Any = handler,
+            M: type[BaseModel] = request_model,
+            rt: RouteTable = route_table,
+            tname: str = tool_name,
+        ):
+            def _endpoint(data: M) -> Any:  # ty: ignore[invalid-type-form]
+                current_route = rt.get_route(tname)
+                if current_route is None or not current_route.enabled:
+                    raise HTTPException(
+                        status_code=503,
+                        detail=f"Tool '{tname}' is currently disabled",
+                    )
+                return h(**data.model_dump())
+
+            return _endpoint
+
+        router.add_api_route(
+            route.path,
+            _make_sync_endpoint(),
+            methods=["POST"],
+            operation_id=route.tool_name,
+            summary=summary,
+            tags=tags,  # ty: ignore[invalid-argument-type]
+        )
+
+
+def route_table_to_router(
+    route_table: RouteTable,
+    prefix: str = "",
+) -> "APIRouter":  # noqa: F821
+    """Convert a :class:`~toolregistry_server.RouteTable` into a FastAPI router.
+
+    Routes are generated for **all** registered tools regardless of their
+    current enabled/disabled state. Each endpoint checks the route's enabled
+    state at request time and returns HTTP 503 if the tool has been disabled,
+    allowing runtime enable/disable without restarting the server.
+
+    Args:
+        route_table: The route table to convert.
+        prefix: URL prefix for all generated routes.
+
+    Returns:
+        A :class:`~fastapi.APIRouter` with one POST route per registered tool.
+
+    Raises:
+        ImportError: If FastAPI is not installed.
+    """
+    try:
+        from fastapi import APIRouter
+    except ImportError as e:
+        raise ImportError(
+            "FastAPI is required for OpenAPI support. "
+            "Install with: pip install toolregistry-server[openapi]"
+        ) from e
+
+    router = APIRouter(prefix=prefix)
+
+    for route in route_table.list_routes(enabled_only=False):
+        _add_route_from_entry(router, route, route_table)
+
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Dynamic OpenAPI schema generation
+# ---------------------------------------------------------------------------
+
+
+def setup_dynamic_openapi(app: "FastAPI", route_table: RouteTable) -> None:  # noqa: F821
+    """Configure dynamic OpenAPI schema generation that filters out disabled tools.
+
+    This replaces FastAPI's default cached OpenAPI schema with a dynamic one
+    that checks tool enable/disable status on every request to ``/openapi.json``.
+    Disabled tools are excluded from the schema so they do not appear in
+    ``/docs`` or ``/openapi.json``, and re-enabling them makes them visible
+    again immediately.
+
+    Args:
+        app: The FastAPI application instance.
+        route_table: The route table used for enable/disable status checks.
+    """
+    try:
+        from fastapi.openapi.utils import get_openapi
+    except ImportError as e:
+        raise ImportError(
+            "FastAPI is required for OpenAPI support. "
+            "Install with: pip install toolregistry-server[openapi]"
+        ) from e
+
+    def custom_openapi() -> dict[str, Any]:
+        # Generate a fresh OpenAPI schema on every call (no caching)
+        # so it always reflects the current enable/disable state.
+        openapi_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+
+        # Collect operation_ids of disabled tools
+        disabled_operation_ids: set[str] = set()
+        for route in route_table.list_routes(enabled_only=False):
+            if not route.enabled:
+                disabled_operation_ids.add(route.tool_name)
+
+        # Filter out paths whose operations correspond to disabled tools
+        if disabled_operation_ids and "paths" in openapi_schema:
+            filtered_paths: dict[str, Any] = {}
+            for path, path_item in openapi_schema["paths"].items():
+                filtered_methods: dict[str, Any] = {}
+                for method, operation in path_item.items():
+                    if isinstance(operation, dict):
+                        op_id = operation.get("operationId", "")
+                        if op_id not in disabled_operation_ids:
+                            filtered_methods[method] = operation
+                    else:
+                        filtered_methods[method] = operation
+                if filtered_methods:
+                    filtered_paths[path] = filtered_methods
+            openapi_schema["paths"] = filtered_paths
+
+        # Do NOT cache (app.openapi_schema is not set) so the schema
+        # is regenerated on every request, reflecting runtime changes.
+        return openapi_schema
+
+    app.openapi = custom_openapi  # ty: ignore[invalid-assignment]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,228 @@
+"""Tests for the authentication module."""
+
+import pytest
+
+from toolregistry_server.auth import (
+    BearerTokenAuth,
+    create_bearer_dependency,
+    verify_token,
+)
+
+# ============== BearerTokenAuth Tests ==============
+
+
+class TestBearerTokenAuth:
+    """Tests for BearerTokenAuth class."""
+
+    def test_init_with_tokens(self):
+        """Test initialization with tokens."""
+        auth = BearerTokenAuth(tokens=["token1", "token2"])
+        assert auth.enabled
+        assert "token1" in auth.tokens
+        assert "token2" in auth.tokens
+
+    def test_init_without_tokens(self):
+        """Test initialization without tokens."""
+        auth = BearerTokenAuth()
+        assert not auth.enabled
+        assert len(auth.tokens) == 0
+
+    def test_init_with_empty_list(self):
+        """Test initialization with empty list."""
+        auth = BearerTokenAuth(tokens=[])
+        assert not auth.enabled
+
+    def test_verify_valid_token(self):
+        """Test verifying a valid token."""
+        auth = BearerTokenAuth(tokens=["secret"])
+        assert auth.verify("secret")
+
+    def test_verify_invalid_token(self):
+        """Test verifying an invalid token."""
+        auth = BearerTokenAuth(tokens=["secret"])
+        assert not auth.verify("wrong")
+
+    def test_verify_when_disabled(self):
+        """Test that verification passes when auth is disabled."""
+        auth = BearerTokenAuth()
+        assert auth.verify("any-token")
+
+    def test_add_token(self):
+        """Test adding a token."""
+        auth = BearerTokenAuth()
+        assert not auth.enabled
+
+        auth.add_token("new-token")
+        assert auth.enabled
+        assert auth.verify("new-token")
+
+    def test_remove_token(self):
+        """Test removing a token."""
+        auth = BearerTokenAuth(tokens=["token1", "token2"])
+        auth.remove_token("token1")
+
+        assert not auth.verify("token1")
+        assert auth.verify("token2")
+        assert auth.enabled
+
+    def test_remove_last_token_disables_auth(self):
+        """Test that removing the last token disables auth."""
+        auth = BearerTokenAuth(tokens=["only-token"])
+        auth.remove_token("only-token")
+
+        assert not auth.enabled
+
+    def test_tokens_property_returns_copy(self):
+        """Test that tokens property returns a copy."""
+        auth = BearerTokenAuth(tokens=["token"])
+        tokens = auth.tokens
+        tokens.add("new")
+
+        # Original should not be modified
+        assert "new" not in auth.tokens
+
+
+# ============== verify_token Tests ==============
+
+
+class TestVerifyToken:
+    """Tests for verify_token function."""
+
+    def test_valid_token(self):
+        """Test verifying a valid token."""
+        assert verify_token("secret", ["secret", "other"])
+
+    def test_invalid_token(self):
+        """Test verifying an invalid token."""
+        assert not verify_token("wrong", ["secret", "other"])
+
+    def test_empty_valid_tokens(self):
+        """Test with empty valid tokens list."""
+        assert not verify_token("any", [])
+
+
+# ============== create_bearer_dependency Tests ==============
+
+
+class TestCreateBearerDependency:
+    """Tests for create_bearer_dependency function."""
+
+    def test_creates_dependency(self):
+        """Test that dependency is created."""
+        auth = BearerTokenAuth(tokens=["secret"])
+        dep = create_bearer_dependency(auth)
+        assert callable(dep)
+
+    @pytest.mark.asyncio
+    async def test_dependency_with_valid_token(self):
+        """Test dependency with valid token."""
+        from unittest.mock import MagicMock
+
+        auth = BearerTokenAuth(tokens=["secret"])
+        dep = create_bearer_dependency(auth)
+
+        # Mock credentials
+        credentials = MagicMock()
+        credentials.credentials = "secret"
+
+        result = await dep(credentials)
+        assert result == "secret"
+
+    @pytest.mark.asyncio
+    async def test_dependency_with_invalid_token(self):
+        """Test dependency with invalid token raises HTTPException."""
+        from unittest.mock import MagicMock
+
+        from fastapi import HTTPException
+
+        auth = BearerTokenAuth(tokens=["secret"])
+        dep = create_bearer_dependency(auth)
+
+        # Mock credentials
+        credentials = MagicMock()
+        credentials.credentials = "wrong"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(credentials)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_dependency_when_auth_disabled(self):
+        """Test dependency when auth is disabled."""
+        from unittest.mock import MagicMock
+
+        auth = BearerTokenAuth()  # No tokens = disabled
+        dep = create_bearer_dependency(auth)
+
+        # Mock credentials
+        credentials = MagicMock()
+        credentials.credentials = "any"
+
+        result = await dep(credentials)
+        assert result == ""
+
+
+# ============== Integration Tests ==============
+
+
+class TestAuthIntegration:
+    """Integration tests for authentication with FastAPI."""
+
+    def test_protected_endpoint(self):
+        """Test that protected endpoint requires auth."""
+        from fastapi import Depends, FastAPI
+        from fastapi.testclient import TestClient
+
+        auth = BearerTokenAuth(tokens=["secret-token"])
+        dep = create_bearer_dependency(auth)
+
+        app = FastAPI(dependencies=[Depends(dep)])
+
+        @app.get("/protected")
+        def protected():
+            return {"message": "success"}
+
+        client = TestClient(app)
+
+        # Without token - HTTPBearer returns 401 or 403 depending on version
+        response = client.get("/protected")
+        assert response.status_code in (401, 403)
+
+        # With invalid token
+        response = client.get(
+            "/protected",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert response.status_code == 401
+
+        # With valid token
+        response = client.get(
+            "/protected",
+            headers={"Authorization": "Bearer secret-token"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"message": "success"}
+
+    def test_unprotected_endpoint_when_disabled(self):
+        """Test that endpoint is accessible when auth is disabled."""
+        from fastapi import Depends, FastAPI
+        from fastapi.testclient import TestClient
+
+        auth = BearerTokenAuth()  # No tokens = disabled
+        dep = create_bearer_dependency(auth)
+
+        app = FastAPI(dependencies=[Depends(dep)])
+
+        @app.get("/public")
+        def public():
+            return {"message": "public"}
+
+        client = TestClient(app)
+
+        # Should still require Bearer header format but accept any token
+        response = client.get(
+            "/public",
+            headers={"Authorization": "Bearer any-token"},
+        )
+        assert response.status_code == 200

--- a/tests/test_openapi_adapter.py
+++ b/tests/test_openapi_adapter.py
@@ -1,0 +1,304 @@
+"""Tests for the OpenAPI adapter module."""
+
+import pytest
+from toolregistry import ToolRegistry
+
+from toolregistry_server import RouteTable
+from toolregistry_server.openapi import create_openapi_app
+from toolregistry_server.openapi.adapter import (
+    _resolve_type,
+    _schema_to_pydantic,
+    route_table_to_router,
+    setup_dynamic_openapi,
+)
+
+# ============== Fixtures ==============
+
+
+@pytest.fixture
+def registry() -> ToolRegistry:
+    """Create a ToolRegistry with sample tools."""
+    reg = ToolRegistry()
+
+    @reg.register
+    def greet(name: str) -> str:
+        """Greet someone by name."""
+        return f"Hello, {name}!"
+
+    @reg.register
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    @reg.register
+    async def async_greet(name: str) -> str:
+        """Async greeting."""
+        return f"Hello async, {name}!"
+
+    return reg
+
+
+@pytest.fixture
+def route_table(registry: ToolRegistry) -> RouteTable:
+    """Create a RouteTable from the registry."""
+    return RouteTable(registry)
+
+
+# ============== Type Resolution Tests ==============
+
+
+class TestResolveType:
+    """Tests for _resolve_type function."""
+
+    def test_string_type(self):
+        """Test resolving string type."""
+        result = _resolve_type({"type": "string"})
+        assert result is str
+
+    def test_integer_type(self):
+        """Test resolving integer type."""
+        result = _resolve_type({"type": "integer"})
+        assert result is int
+
+    def test_number_type(self):
+        """Test resolving number type."""
+        result = _resolve_type({"type": "number"})
+        assert result is float
+
+    def test_boolean_type(self):
+        """Test resolving boolean type."""
+        result = _resolve_type({"type": "boolean"})
+        assert result is bool
+
+    def test_array_type_simple(self):
+        """Test resolving simple array type."""
+        result = _resolve_type({"type": "array"})
+        assert result is list
+
+    def test_array_type_with_items(self):
+        """Test resolving array type with items."""
+        result = _resolve_type({"type": "array", "items": {"type": "string"}})
+        assert result == list[str]
+
+    def test_enum_type(self):
+        """Test resolving enum type to Literal."""
+        from typing import get_args
+
+        result = _resolve_type({"enum": ["a", "b", "c"]})
+        # Check it's a Literal type with correct values
+        assert get_args(result) == ("a", "b", "c")
+
+    def test_anyof_optional(self):
+        """Test resolving anyOf with null (Optional pattern)."""
+        result = _resolve_type({"anyOf": [{"type": "string"}, {"type": "null"}]})
+        assert result is str
+
+
+class TestSchemaToPydantic:
+    """Tests for _schema_to_pydantic function."""
+
+    def test_empty_schema(self):
+        """Test creating model from empty schema."""
+        from pydantic import BaseModel
+
+        model = _schema_to_pydantic("EmptyModel", {})
+        assert issubclass(model, BaseModel)
+
+    def test_simple_schema(self):
+        """Test creating model from simple schema."""
+        schema = {
+            "properties": {
+                "name": {"type": "string", "description": "The name"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name"],
+        }
+        model = _schema_to_pydantic("PersonModel", schema)
+
+        # Check fields exist
+        assert "name" in model.model_fields
+        assert "age" in model.model_fields
+
+        # Check required field
+        assert model.model_fields["name"].is_required()
+        assert not model.model_fields["age"].is_required()
+
+    def test_schema_with_defaults(self):
+        """Test creating model with default values."""
+        schema = {
+            "properties": {
+                "count": {"type": "integer", "default": 10},
+            },
+        }
+        model = _schema_to_pydantic("CountModel", schema)
+
+        # Create instance without providing count
+        instance = model()
+        assert instance.count == 10
+
+
+# ============== Router Generation Tests ==============
+
+
+class TestRouteTableToRouter:
+    """Tests for route_table_to_router function."""
+
+    def test_creates_router(self, route_table: RouteTable):
+        """Test that router is created successfully."""
+        from fastapi import APIRouter
+
+        router = route_table_to_router(route_table)
+        assert isinstance(router, APIRouter)
+
+    def test_router_has_routes(self, route_table: RouteTable):
+        """Test that router has routes for all tools."""
+        router = route_table_to_router(route_table)
+        # Should have routes for greet, add, and async_greet
+        assert len(router.routes) >= 3
+
+    def test_router_with_prefix(self, route_table: RouteTable):
+        """Test router with custom prefix."""
+        router = route_table_to_router(route_table, prefix="/api")
+        assert router.prefix == "/api"
+
+
+# ============== App Creation Tests ==============
+
+
+class TestCreateOpenAPIApp:
+    """Tests for create_openapi_app function."""
+
+    def test_creates_app(self, route_table: RouteTable):
+        """Test that app is created successfully."""
+        from fastapi import FastAPI
+
+        app = create_openapi_app(route_table)
+        assert isinstance(app, FastAPI)
+
+    def test_app_with_custom_metadata(self, route_table: RouteTable):
+        """Test app with custom title and version."""
+        app = create_openapi_app(
+            route_table,
+            title="Test API",
+            version="2.0.0",
+            description="Test description",
+        )
+        assert app.title == "Test API"
+        assert app.version == "2.0.0"
+        assert app.description == "Test description"
+
+
+# ============== Integration Tests ==============
+
+
+class TestOpenAPIIntegration:
+    """Integration tests using TestClient."""
+
+    def test_sync_endpoint(self, route_table: RouteTable):
+        """Test calling a sync endpoint."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        response = client.post(
+            "/tools/default/add",
+            json={"a": 2, "b": 3},
+        )
+        assert response.status_code == 200
+        assert response.json() == 5
+
+    def test_async_endpoint(self, route_table: RouteTable):
+        """Test calling an async endpoint."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        response = client.post(
+            "/tools/default/async_greet",
+            json={"name": "World"},
+        )
+        assert response.status_code == 200
+        assert response.json() == "Hello async, World!"
+
+    def test_disabled_tool_returns_503(self, route_table: RouteTable):
+        """Test that disabled tools return 503."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        # Disable the tool
+        route_table.disable("add", reason="Testing")
+
+        response = client.post(
+            "/tools/default/add",
+            json={"a": 2, "b": 3},
+        )
+        assert response.status_code == 503
+        assert "disabled" in response.json()["detail"].lower()
+
+    def test_openapi_schema_excludes_disabled(self, route_table: RouteTable):
+        """Test that OpenAPI schema excludes disabled tools."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        # Get schema before disabling
+        response = client.get("/openapi.json")
+        schema_before = response.json()
+        assert "/tools/default/add" in schema_before["paths"]
+
+        # Disable the tool
+        route_table.disable("add", reason="Testing")
+
+        # Get schema after disabling
+        response = client.get("/openapi.json")
+        schema_after = response.json()
+        assert "/tools/default/add" not in schema_after["paths"]
+
+
+# ============== Dynamic OpenAPI Tests ==============
+
+
+class TestDynamicOpenAPI:
+    """Tests for setup_dynamic_openapi function."""
+
+    def test_dynamic_schema_updates(self, route_table: RouteTable):
+        """Test that schema updates dynamically."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from toolregistry_server.openapi.adapter import route_table_to_router
+
+        app = FastAPI()
+        router = route_table_to_router(route_table)
+        app.include_router(router)
+        setup_dynamic_openapi(app, route_table)
+
+        client = TestClient(app)
+
+        # Initially all tools visible
+        response = client.get("/openapi.json")
+        paths = response.json()["paths"]
+        assert "/tools/default/greet" in paths
+        assert "/tools/default/add" in paths
+
+        # Disable one tool
+        route_table.disable("greet")
+
+        # Schema should update
+        response = client.get("/openapi.json")
+        paths = response.json()["paths"]
+        assert "/tools/default/greet" not in paths
+        assert "/tools/default/add" in paths
+
+        # Re-enable
+        route_table.enable("greet")
+
+        # Schema should update again
+        response = client.get("/openapi.json")
+        paths = response.json()["paths"]
+        assert "/tools/default/greet" in paths


### PR DESCRIPTION
## Summary
Implement the OpenAPI adapter module that converts RouteTable entries into FastAPI routes.

## Changes
- Add `openapi/adapter.py` with route generation from RouteTable
- Implement `_resolve_type` and `_schema_to_pydantic` for dynamic Pydantic model creation
- Add `route_table_to_router` for FastAPI router generation
- Add `setup_dynamic_openapi` for runtime tool enable/disable in OpenAPI schema
- Enhance auth module with `create_bearer_dependency` for FastAPI dependency injection
- Add comprehensive tests for OpenAPI adapter and auth module (59 tests passing)
- Fix pyproject.toml license classifier conflict

## Testing
All 59 tests pass:
- 21 tests for OpenAPI adapter
- 19 tests for auth module
- 19 tests for RouteTable

Closes #3