### PR TITLE
feat(mcp): implement MCP adapter with RouteTable integration

### DIFF
--- a/src/toolregistry_server/mcp/__init__.py
+++ b/src/toolregistry_server/mcp/__init__.py
@@ -5,17 +5,22 @@ This module provides functionality to expose ToolRegistry tools via
 the Model Context Protocol for LLM integration.
 
 Main Components:
-    - create_mcp_server: Create an MCP server from a RouteTable
-    - route_table_to_mcp_server: Convert a RouteTable to an MCP server
+    - route_table_to_mcp_server: Convert a RouteTable to an MCP low-level server
+    - create_mcp_server: Alias for route_table_to_mcp_server
+    - run_stdio: Run MCP server over stdio transport
+    - run_sse: Run MCP server over SSE transport
+    - run_streamable_http: Run MCP server over streamable HTTP transport
 
 Example:
+    >>> import asyncio
     >>> from toolregistry import ToolRegistry
     >>> from toolregistry_server import RouteTable
-    >>> from toolregistry_server.mcp import create_mcp_server
+    >>> from toolregistry_server.mcp import create_mcp_server, run_stdio
     >>>
     >>> registry = ToolRegistry()
     >>> route_table = RouteTable(registry)
     >>> server = create_mcp_server(route_table)
+    >>> asyncio.run(run_stdio(server))
 
 Note:
     This module requires the 'mcp' extra to be installed:
@@ -36,6 +41,8 @@ def create_mcp_server(
 ) -> "Server":
     """Create an MCP server from a RouteTable.
 
+    This is an alias for route_table_to_mcp_server() for convenience.
+
     Args:
         route_table: The RouteTable to expose.
         name: Server name for MCP identification.
@@ -46,6 +53,8 @@ def create_mcp_server(
     Raises:
         ImportError: If MCP SDK is not installed.
     """
+    from .adapter import route_table_to_mcp_server
+
     return route_table_to_mcp_server(route_table, name)
 
 
@@ -53,7 +62,11 @@ def route_table_to_mcp_server(
     route_table: "RouteTable",
     name: str = "ToolRegistry-Server",
 ) -> "Server":
-    """Create an MCP server from a RouteTable.
+    """Create an MCP low-level server from a RouteTable.
+
+    Registers list_tools and call_tool handlers that read directly
+    from the route table, ensuring enable/disable state is always
+    in sync (no drift).
 
     Args:
         route_table: The RouteTable to convert.
@@ -65,37 +78,73 @@ def route_table_to_mcp_server(
     Raises:
         ImportError: If MCP SDK is not installed.
     """
-    try:
-        from mcp.server.lowlevel import Server
-        from mcp.types import Tool as MCPTool
-    except ImportError as e:
-        raise ImportError(
-            "MCP SDK is required for MCP support. "
-            "Install with: pip install toolregistry-server[mcp]"
-        ) from e
+    from .adapter import route_table_to_mcp_server as _route_table_to_mcp_server
 
-    server = Server(name)
+    return _route_table_to_mcp_server(route_table, name)
 
-    @server.list_tools()
-    async def handle_list_tools() -> list[MCPTool]:
-        """List all available tools."""
-        return [
-            MCPTool(
-                name=route.tool_name,
-                description=route.description,
-                inputSchema=route.parameters_schema,
-            )
-            for route in route_table.list_routes(enabled_only=True)
-        ]
 
-    # TODO: Implement call_tool handler
-    # This is a skeleton implementation - full implementation will be
-    # migrated from toolregistry-hub's mcp_adapter.py
+async def run_stdio(server: "Server") -> None:
+    """Run an MCP server over stdio transport.
 
-    return server
+    This is the simplest transport, suitable for local tool execution
+    where the MCP client spawns the server as a subprocess.
+
+    Args:
+        server: The MCP Server instance to run.
+    """
+    from .server import run_stdio as _run_stdio
+
+    await _run_stdio(server)
+
+
+async def run_sse(
+    server: "Server",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    path: str = "/sse",
+) -> None:
+    """Run an MCP server over SSE (Server-Sent Events) transport.
+
+    This transport is suitable for web-based MCP clients that connect
+    via HTTP and receive events through SSE.
+
+    Args:
+        server: The MCP Server instance to run.
+        host: Host address to bind to.
+        port: Port number to bind to.
+        path: URL path for the SSE endpoint.
+    """
+    from .server import run_sse as _run_sse
+
+    await _run_sse(server, host, port, path)
+
+
+async def run_streamable_http(
+    server: "Server",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    path: str = "/mcp",
+) -> None:
+    """Run an MCP server over streamable HTTP transport.
+
+    This is the recommended HTTP transport for production use,
+    supporting bidirectional streaming over HTTP.
+
+    Args:
+        server: The MCP Server instance to run.
+        host: Host address to bind to.
+        port: Port number to bind to.
+        path: URL path for the MCP endpoint.
+    """
+    from .server import run_streamable_http as _run_streamable_http
+
+    await _run_streamable_http(server, host, port, path)
 
 
 __all__ = [
     "create_mcp_server",
     "route_table_to_mcp_server",
+    "run_stdio",
+    "run_sse",
+    "run_streamable_http",
 ]

--- a/src/toolregistry_server/mcp/adapter.py
+++ b/src/toolregistry_server/mcp/adapter.py
@@ -1,0 +1,163 @@
+"""MCP adapter that creates an MCP low-level Server from a RouteTable.
+
+This module bridges RouteTable and the MCP Python SDK's low-level Server API,
+ensuring tool enable/disable state is always read directly from the route table
+at request time (no drift).
+"""
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from mcp.server.lowlevel import Server
+
+    from ..route_table import RouteTable
+
+
+def _serialize_result(result: Any) -> str:
+    """Convert tool result to a string for MCP TextContent.
+
+    Handles:
+    - str → returned directly
+    - dict/list/Pydantic model → JSON-serialized
+    - Other types → str() fallback
+
+    Args:
+        result: The tool execution result.
+
+    Returns:
+        A string representation of the result.
+    """
+    if isinstance(result, str):
+        return result
+
+    # Try JSON serialization for structured data
+    try:
+        if hasattr(result, "model_dump"):
+            # Pydantic model
+            return json.dumps(result.model_dump(), ensure_ascii=False, default=str)
+        elif isinstance(result, (dict, list)):
+            return json.dumps(result, ensure_ascii=False, default=str)
+        else:
+            return str(result)
+    except (TypeError, ValueError):
+        return str(result)
+
+
+def route_table_to_mcp_server(
+    route_table: "RouteTable",
+    name: str = "ToolRegistry-Server",
+) -> "Server":
+    """Create an MCP low-level Server from a RouteTable.
+
+    Registers list_tools and call_tool handlers that read directly
+    from the route table, ensuring enable/disable state is always
+    in sync (no drift).
+
+    Args:
+        route_table: The RouteTable instance to expose as MCP tools.
+        name: Server name for MCP identification.
+
+    Returns:
+        A configured mcp.server.lowlevel.Server instance.
+
+    Raises:
+        ImportError: If MCP SDK is not installed.
+    """
+    try:
+        from mcp.server.lowlevel import Server
+        from mcp.shared.exceptions import McpError
+        from mcp.types import INTERNAL_ERROR, ErrorData, TextContent
+        from mcp.types import Tool as MCPTool
+    except ImportError as e:
+        raise ImportError(
+            "MCP SDK is required for MCP support. "
+            "Install with: pip install toolregistry-server[mcp]"
+        ) from e
+
+    server = Server(name)
+
+    @server.list_tools()
+    async def handle_list_tools() -> list[MCPTool]:
+        """Return MCP tool definitions for all enabled tools in the route table."""
+        tools: list[MCPTool] = []
+        for route in route_table.list_routes(enabled_only=True):
+            tools.append(
+                MCPTool(
+                    name=route.tool_name,
+                    description=route.description or "",
+                    inputSchema=route.parameters_schema,
+                )
+            )
+        logger.debug(f"list_tools: returning {len(tools)} enabled tools")
+        return tools
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict) -> list[TextContent]:
+        """Execute a tool by name with the given arguments.
+
+        Args:
+            name: The tool name to invoke.
+            arguments: The input arguments for the tool.
+
+        Returns:
+            A list containing a single TextContent with the result.
+
+        Raises:
+            McpError: If the tool is disabled or not found.
+        """
+        # Get the route entry
+        route = route_table.get_route(name)
+
+        # Check if tool exists
+        if route is None:
+            raise McpError(
+                ErrorData(
+                    code=INTERNAL_ERROR,
+                    message=f"Tool '{name}' not found",
+                )
+            )
+
+        # Check if tool is disabled
+        if not route.enabled:
+            reason = route.disable_reason or "unknown reason"
+            raise McpError(
+                ErrorData(
+                    code=INTERNAL_ERROR,
+                    message=f"Tool '{name}' is disabled: {reason}",
+                )
+            )
+
+        try:
+            # Execute the tool handler
+            if route.is_async:
+                result = await route.handler(**arguments)
+            else:
+                result = route.handler(**arguments)
+
+            # Serialize result to text
+            text = _serialize_result(result)
+
+            logger.debug(f"call_tool '{name}': success")
+            return [TextContent(type="text", text=text)]
+
+        except McpError:
+            raise
+        except Exception as e:
+            logger.warning(f"call_tool '{name}': error - {e}")
+            # Return error as content; the SDK's handler wrapper will catch
+            # exceptions and set isError=True via _make_error_result.
+            raise McpError(
+                ErrorData(
+                    code=INTERNAL_ERROR,
+                    message=str(e),
+                )
+            ) from e
+
+    logger.info(
+        f"MCP server '{name}' created with {len(route_table.list_routes())} "
+        f"enabled tool(s) out of {len(route_table.list_routes(enabled_only=False))} total"
+    )
+    return server

--- a/src/toolregistry_server/mcp/server.py
+++ b/src/toolregistry_server/mcp/server.py
@@ -1,0 +1,181 @@
+"""MCP server runner functions.
+
+This module provides functions to run an MCP server with different transports:
+- stdio: Standard input/output transport
+- SSE: Server-Sent Events over HTTP
+- streamable-http: Streamable HTTP transport
+
+The server should be created using route_table_to_mcp_server() from adapter.py,
+then run using the functions in this module.
+
+Example:
+    >>> from toolregistry import ToolRegistry
+    >>> from toolregistry_server import RouteTable
+    >>> from toolregistry_server.mcp import route_table_to_mcp_server, run_stdio
+    >>>
+    >>> registry = ToolRegistry()
+    >>> route_table = RouteTable(registry)
+    >>> server = route_table_to_mcp_server(route_table)
+    >>> asyncio.run(run_stdio(server))
+"""
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from mcp.server.lowlevel import Server
+
+
+async def run_stdio(server: "Server") -> None:
+    """Run an MCP server over stdio transport.
+
+    This is the simplest transport, suitable for local tool execution
+    where the MCP client spawns the server as a subprocess.
+
+    Args:
+        server: The MCP Server instance to run.
+    """
+    try:
+        from mcp.server.stdio import stdio_server
+    except ImportError as e:
+        raise ImportError(
+            "MCP SDK is required for MCP support. "
+            "Install with: pip install toolregistry-server[mcp]"
+        ) from e
+
+    logger.info("Starting MCP server with stdio transport")
+    try:
+        async with stdio_server() as (read, write):
+            await server.run(
+                read,
+                write,
+                server.create_initialization_options(),
+            )
+    except KeyboardInterrupt:
+        logger.info("MCP stdio server shutdown requested (KeyboardInterrupt)")
+    except asyncio.CancelledError:
+        logger.info("MCP stdio server shutdown requested (CancelledError)")
+
+
+async def run_sse(
+    server: "Server",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    path: str = "/sse",
+) -> None:
+    """Run an MCP server over SSE (Server-Sent Events) transport.
+
+    This transport is suitable for web-based MCP clients that connect
+    via HTTP and receive events through SSE.
+
+    Args:
+        server: The MCP Server instance to run.
+        host: Host address to bind to.
+        port: Port number to bind to.
+        path: URL path for the SSE endpoint.
+    """
+    try:
+        import uvicorn
+        from mcp.server.sse import SseServerTransport
+        from starlette.applications import Starlette
+        from starlette.routing import Mount, Route
+    except ImportError as e:
+        raise ImportError(
+            "MCP SDK and Starlette are required for SSE transport. "
+            "Install with: pip install toolregistry-server[mcp] starlette uvicorn"
+        ) from e
+
+    logger.info(f"Starting MCP server with SSE transport on {host}:{port}{path}")
+
+    # Create SSE transport
+    sse = SseServerTransport(f"{path}/messages/")
+
+    async def handle_sse(scope, receive, send):
+        async with sse.connect_sse(scope, receive, send) as streams:
+            await server.run(
+                streams[0],
+                streams[1],
+                server.create_initialization_options(),
+            )
+
+    # Create Starlette app
+    routes = [
+        Route(path, endpoint=handle_sse, methods=["GET"]),
+        Mount(f"{path}/messages/", app=sse.handle_post_message),
+    ]
+    app = Starlette(routes=routes)
+
+    # Run with uvicorn
+    config = uvicorn.Config(app, host=host, port=port, log_level="info")
+    uvicorn_server = uvicorn.Server(config)
+
+    try:
+        await uvicorn_server.serve()
+    except KeyboardInterrupt:
+        logger.info("MCP SSE server shutdown requested (KeyboardInterrupt)")
+    except asyncio.CancelledError:
+        logger.info("MCP SSE server shutdown requested (CancelledError)")
+
+
+async def run_streamable_http(
+    server: "Server",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    path: str = "/mcp",
+) -> None:
+    """Run an MCP server over streamable HTTP transport.
+
+    This is the recommended HTTP transport for production use,
+    supporting bidirectional streaming over HTTP.
+
+    Args:
+        server: The MCP Server instance to run.
+        host: Host address to bind to.
+        port: Port number to bind to.
+        path: URL path for the MCP endpoint.
+    """
+    try:
+        import uvicorn
+        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+    except ImportError as e:
+        raise ImportError(
+            "MCP SDK and Starlette are required for streamable HTTP transport. "
+            "Install with: pip install toolregistry-server[mcp] starlette uvicorn"
+        ) from e
+
+    logger.info(
+        f"Starting MCP server with streamable HTTP transport on {host}:{port}{path}"
+    )
+
+    # Create session manager
+    session_manager = StreamableHTTPSessionManager(
+        app=server,
+        json_response=False,
+        stateless=False,
+    )
+
+    # Create ASGI handler
+    async def handle_mcp(scope, receive, send):
+        await session_manager.handle_request(scope, receive, send)
+
+    # Create Starlette app with lifespan
+    routes = [Route(path, endpoint=handle_mcp)]
+    app = Starlette(
+        routes=routes,
+        lifespan=lambda app: session_manager.run(),
+    )
+
+    # Run with uvicorn
+    config = uvicorn.Config(app, host=host, port=port, log_level="info")
+    uvicorn_server = uvicorn.Server(config)
+
+    try:
+        await uvicorn_server.serve()
+    except KeyboardInterrupt:
+        logger.info("MCP streamable HTTP server shutdown requested (KeyboardInterrupt)")
+    except asyncio.CancelledError:
+        logger.info("MCP streamable HTTP server shutdown requested (CancelledError)")

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,0 +1,682 @@
+"""Tests for the MCP adapter that bridges RouteTable to MCP Server.
+
+Uses the MCP SDK's in-memory transport (create_connected_server_and_client_session)
+for end-to-end testing of list_tools and call_tool handlers.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.server.lowlevel import Server
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from toolregistry_server import RouteEntry, RouteTable
+from toolregistry_server.mcp import create_mcp_server, route_table_to_mcp_server
+
+# ---------------------------------------------------------------------------
+# Test helper functions
+# ---------------------------------------------------------------------------
+
+
+def add(a: int, b: int) -> int:
+    """Add two integers.
+
+    Args:
+        a: First operand.
+        b: Second operand.
+
+    Returns:
+        Sum of a and b.
+    """
+    return a + b
+
+
+def multiply(a: int, b: int) -> int:
+    """Multiply two integers.
+
+    Args:
+        a: First operand.
+        b: Second operand.
+
+    Returns:
+        Product of a and b.
+    """
+    return a * b
+
+
+def greet(name: str) -> str:
+    """Return a greeting string.
+
+    Args:
+        name: Name to greet.
+
+    Returns:
+        A greeting message.
+    """
+    return f"Hello, {name}!"
+
+
+def get_info() -> dict:
+    """Return a sample info dict.
+
+    Returns:
+        A dictionary with sample data.
+    """
+    return {"status": "ok", "count": 42}
+
+
+def get_pi() -> float:
+    """Return the value of pi.
+
+    Returns:
+        Pi approximation.
+    """
+    return 3.14159
+
+
+def get_answer() -> int:
+    """Return the answer to everything.
+
+    Returns:
+        The number 42.
+    """
+    return 42
+
+
+def failing_tool() -> str:
+    """A tool that always raises an exception.
+
+    Returns:
+        Never returns normally.
+
+    Raises:
+        ValueError: Always.
+    """
+    raise ValueError("intentional error for testing")
+
+
+async def async_add(a: int, b: int) -> int:
+    """Asynchronously add two integers.
+
+    Args:
+        a: First operand.
+        b: Second operand.
+
+    Returns:
+        Sum of a and b.
+    """
+    return a + b
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_registry() -> MagicMock:
+    """Create a mock ToolRegistry."""
+    registry = MagicMock()
+    registry._tools = {}
+    registry.is_enabled = MagicMock(return_value=True)
+    registry.get_disable_reason = MagicMock(return_value=None)
+    return registry
+
+
+@pytest.fixture
+def route_table_with_tools(mock_registry: MagicMock) -> RouteTable:
+    """Create a RouteTable with add and multiply tools."""
+    # Create mock tools
+    add_tool = MagicMock()
+    add_tool.name = "add"
+    add_tool.namespace = "default"
+    add_tool.method_name = "add"
+    add_tool.description = "Add two integers."
+    add_tool.parameters = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer", "description": "First operand."},
+            "b": {"type": "integer", "description": "Second operand."},
+        },
+        "required": ["a", "b"],
+    }
+    add_tool.callable = add
+    add_tool.is_async = False
+
+    multiply_tool = MagicMock()
+    multiply_tool.name = "multiply"
+    multiply_tool.namespace = "default"
+    multiply_tool.method_name = "multiply"
+    multiply_tool.description = "Multiply two integers."
+    multiply_tool.parameters = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer", "description": "First operand."},
+            "b": {"type": "integer", "description": "Second operand."},
+        },
+        "required": ["a", "b"],
+    }
+    multiply_tool.callable = multiply
+    multiply_tool.is_async = False
+
+    mock_registry._tools = {"add": add_tool, "multiply": multiply_tool}
+
+    return RouteTable(mock_registry)
+
+
+# ---------------------------------------------------------------------------
+# 1. route_table_to_mcp_server() basic functionality
+# ---------------------------------------------------------------------------
+
+
+class TestRouteTableToMcpServer:
+    """Tests for route_table_to_mcp_server() basic creation."""
+
+    def test_returns_server_instance(self, route_table_with_tools: RouteTable) -> None:
+        """Verify that route_table_to_mcp_server returns an mcp Server instance."""
+        server = route_table_to_mcp_server(route_table_with_tools)
+        assert isinstance(server, Server)
+
+    def test_create_mcp_server_returns_server_instance(
+        self, route_table_with_tools: RouteTable
+    ) -> None:
+        """Verify that create_mcp_server also returns a Server."""
+        server = create_mcp_server(route_table_with_tools)
+        assert isinstance(server, Server)
+
+    def test_server_has_correct_name(self, route_table_with_tools: RouteTable) -> None:
+        """Verify the server name is set correctly."""
+        server = route_table_to_mcp_server(route_table_with_tools)
+        assert server.name == "ToolRegistry-Server"
+
+    def test_server_custom_name(self, route_table_with_tools: RouteTable) -> None:
+        """Verify custom server name is used."""
+        server = route_table_to_mcp_server(route_table_with_tools, name="Custom-Server")
+        assert server.name == "Custom-Server"
+
+
+# ---------------------------------------------------------------------------
+# 2. list_tools handler
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    """Tests for the list_tools MCP handler."""
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_registered_tools(
+        self, route_table_with_tools: RouteTable
+    ) -> None:
+        """Verify list_tools returns all enabled tools from the route table."""
+        server = route_table_to_mcp_server(route_table_with_tools)
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.list_tools()
+            tool_names = {t.name for t in result.tools}
+            assert tool_names == {"add", "multiply"}
+
+    @pytest.mark.asyncio
+    async def test_list_tools_name_and_description(
+        self, route_table_with_tools: RouteTable
+    ) -> None:
+        """Verify tool name and description are correctly mapped."""
+        server = route_table_to_mcp_server(route_table_with_tools)
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.list_tools()
+            tools_by_name = {t.name: t for t in result.tools}
+
+            assert "add" in tools_by_name
+            assert tools_by_name["add"].description == "Add two integers."
+
+            assert "multiply" in tools_by_name
+            assert tools_by_name["multiply"].description == "Multiply two integers."
+
+    @pytest.mark.asyncio
+    async def test_list_tools_input_schema(
+        self, route_table_with_tools: RouteTable
+    ) -> None:
+        """Verify inputSchema contains correct parameter definitions."""
+        server = route_table_to_mcp_server(route_table_with_tools)
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.list_tools()
+            tools_by_name = {t.name: t for t in result.tools}
+
+            schema = tools_by_name["add"].inputSchema
+            assert schema["type"] == "object"
+            assert "a" in schema["properties"]
+            assert "b" in schema["properties"]
+            assert schema["properties"]["a"]["type"] == "integer"
+            assert schema["properties"]["b"]["type"] == "integer"
+            assert set(schema["required"]) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# 3. enable/disable dynamic reflection (key test)
+# ---------------------------------------------------------------------------
+
+
+class TestEnableDisable:
+    """Tests for dynamic enable/disable reflection in list_tools."""
+
+    @pytest.mark.asyncio
+    async def test_disable_removes_tool_from_list(
+        self, mock_registry: MagicMock
+    ) -> None:
+        """Disabling a tool should remove it from list_tools results."""
+        # Create tools
+        add_tool = MagicMock()
+        add_tool.name = "add"
+        add_tool.namespace = "default"
+        add_tool.method_name = "add"
+        add_tool.description = "Add two integers."
+        add_tool.parameters = {"type": "object", "properties": {}}
+        add_tool.callable = add
+        add_tool.is_async = False
+
+        multiply_tool = MagicMock()
+        multiply_tool.name = "multiply"
+        multiply_tool.namespace = "default"
+        multiply_tool.method_name = "multiply"
+        multiply_tool.description = "Multiply two integers."
+        multiply_tool.parameters = {"type": "object", "properties": {}}
+        multiply_tool.callable = multiply
+        multiply_tool.is_async = False
+
+        mock_registry._tools = {"add": add_tool, "multiply": multiply_tool}
+        mock_registry.get_tool = MagicMock(
+            side_effect=lambda n: mock_registry._tools.get(n)
+        )
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            # Initially both tools are listed
+            result = await client.list_tools()
+            assert {t.name for t in result.tools} == {"add", "multiply"}
+
+            # Disable 'add' by modifying the route entry
+            route = route_table.get_route("add")
+            assert route is not None
+            # Manually update the route entry to simulate disable
+            route_table._routes["add"] = RouteEntry(
+                tool_name=route.tool_name,
+                namespace=route.namespace,
+                method_name=route.method_name,
+                path=route.path,
+                description=route.description,
+                parameters_schema=route.parameters_schema,
+                handler=route.handler,
+                is_async=route.is_async,
+                enabled=False,
+                disable_reason="maintenance",
+            )
+
+            result = await client.list_tools()
+            assert {t.name for t in result.tools} == {"multiply"}
+
+    @pytest.mark.asyncio
+    async def test_enable_restores_tool_to_list(self, mock_registry: MagicMock) -> None:
+        """Re-enabling a tool should restore it in list_tools results."""
+        add_tool = MagicMock()
+        add_tool.name = "add"
+        add_tool.namespace = "default"
+        add_tool.method_name = "add"
+        add_tool.description = "Add two integers."
+        add_tool.parameters = {"type": "object", "properties": {}}
+        add_tool.callable = add
+        add_tool.is_async = False
+
+        mock_registry._tools = {"add": add_tool}
+        mock_registry.get_tool = MagicMock(return_value=add_tool)
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            # Disable then re-enable
+            route = route_table.get_route("add")
+            assert route is not None
+
+            # Disable
+            route_table._routes["add"] = RouteEntry(
+                tool_name=route.tool_name,
+                namespace=route.namespace,
+                method_name=route.method_name,
+                path=route.path,
+                description=route.description,
+                parameters_schema=route.parameters_schema,
+                handler=route.handler,
+                is_async=route.is_async,
+                enabled=False,
+                disable_reason="maintenance",
+            )
+
+            result = await client.list_tools()
+            assert {t.name for t in result.tools} == set()
+
+            # Re-enable
+            route_table._routes["add"] = RouteEntry(
+                tool_name=route.tool_name,
+                namespace=route.namespace,
+                method_name=route.method_name,
+                path=route.path,
+                description=route.description,
+                parameters_schema=route.parameters_schema,
+                handler=route.handler,
+                is_async=route.is_async,
+                enabled=True,
+                disable_reason=None,
+            )
+
+            result = await client.list_tools()
+            assert {t.name for t in result.tools} == {"add"}
+
+
+# ---------------------------------------------------------------------------
+# 4. call_tool handler
+# ---------------------------------------------------------------------------
+
+
+class TestCallTool:
+    """Tests for the call_tool MCP handler."""
+
+    @pytest.mark.asyncio
+    async def test_call_enabled_tool(self, route_table_with_tools: RouteTable) -> None:
+        """Calling an enabled tool should return the correct result."""
+        server = route_table_to_mcp_server(route_table_with_tools)
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("add", {"a": 3, "b": 4})
+            assert result.isError is False
+            assert len(result.content) == 1
+            assert result.content[0].text == "7"
+
+    @pytest.mark.asyncio
+    async def test_call_disabled_tool_returns_error(
+        self, mock_registry: MagicMock
+    ) -> None:
+        """Calling a disabled tool should return isError=True with reason."""
+        add_tool = MagicMock()
+        add_tool.name = "add"
+        add_tool.namespace = "default"
+        add_tool.method_name = "add"
+        add_tool.description = "Add two integers."
+        add_tool.parameters = {"type": "object", "properties": {}}
+        add_tool.callable = add
+        add_tool.is_async = False
+
+        mock_registry._tools = {"add": add_tool}
+        mock_registry.is_enabled = MagicMock(return_value=False)
+        mock_registry.get_disable_reason = MagicMock(return_value="maintenance")
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("add", {"a": 1, "b": 2})
+            assert result.isError is True
+            assert "disabled" in result.content[0].text.lower()
+            assert "maintenance" in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_call_nonexistent_tool_returns_error(
+        self, route_table_with_tools: RouteTable
+    ) -> None:
+        """Calling a non-existent tool should return isError=True."""
+        server = route_table_to_mcp_server(route_table_with_tools)
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("nonexistent", {})
+            assert result.isError is True
+            assert "not found" in result.content[0].text.lower()
+
+
+# ---------------------------------------------------------------------------
+# 5. sync/async tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncAsyncTools:
+    """Tests for both synchronous and asynchronous tool execution."""
+
+    @pytest.mark.asyncio
+    async def test_sync_tool_execution(self, mock_registry: MagicMock) -> None:
+        """A synchronous tool should execute correctly via call_tool."""
+        add_tool = MagicMock()
+        add_tool.name = "add"
+        add_tool.namespace = "default"
+        add_tool.method_name = "add"
+        add_tool.description = "Add two integers."
+        add_tool.parameters = {"type": "object", "properties": {}}
+        add_tool.callable = add
+        add_tool.is_async = False
+
+        mock_registry._tools = {"add": add_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("add", {"a": 10, "b": 20})
+            assert result.isError is False
+            assert result.content[0].text == "30"
+
+    @pytest.mark.asyncio
+    async def test_async_tool_execution(self, mock_registry: MagicMock) -> None:
+        """An asynchronous tool should execute correctly via call_tool."""
+        async_add_tool = MagicMock()
+        async_add_tool.name = "async_add"
+        async_add_tool.namespace = "default"
+        async_add_tool.method_name = "async_add"
+        async_add_tool.description = "Asynchronously add two integers."
+        async_add_tool.parameters = {"type": "object", "properties": {}}
+        async_add_tool.callable = async_add
+        async_add_tool.is_async = True
+
+        mock_registry._tools = {"async_add": async_add_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("async_add", {"a": 5, "b": 7})
+            assert result.isError is False
+            assert result.content[0].text == "12"
+
+    @pytest.mark.asyncio
+    async def test_mixed_sync_async_tools(self, mock_registry: MagicMock) -> None:
+        """Both sync and async tools should coexist and work correctly."""
+        add_tool = MagicMock()
+        add_tool.name = "add"
+        add_tool.namespace = "default"
+        add_tool.method_name = "add"
+        add_tool.description = "Add two integers."
+        add_tool.parameters = {"type": "object", "properties": {}}
+        add_tool.callable = add
+        add_tool.is_async = False
+
+        async_add_tool = MagicMock()
+        async_add_tool.name = "async_add"
+        async_add_tool.namespace = "default"
+        async_add_tool.method_name = "async_add"
+        async_add_tool.description = "Asynchronously add two integers."
+        async_add_tool.parameters = {"type": "object", "properties": {}}
+        async_add_tool.callable = async_add
+        async_add_tool.is_async = True
+
+        mock_registry._tools = {"add": add_tool, "async_add": async_add_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            # Verify both are listed
+            tools_result = await client.list_tools()
+            tool_names = {t.name for t in tools_result.tools}
+            assert tool_names == {"add", "async_add"}
+
+            # Call sync tool
+            r1 = await client.call_tool("add", {"a": 1, "b": 2})
+            assert r1.content[0].text == "3"
+
+            # Call async tool
+            r2 = await client.call_tool("async_add", {"a": 3, "b": 4})
+            assert r2.content[0].text == "7"
+
+
+# ---------------------------------------------------------------------------
+# 6. Result serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestResultSerialization:
+    """Tests for result serialization in call_tool responses."""
+
+    @pytest.mark.asyncio
+    async def test_dict_result_json_serialized(self, mock_registry: MagicMock) -> None:
+        """A dict result should be JSON-serialized."""
+        info_tool = MagicMock()
+        info_tool.name = "get_info"
+        info_tool.namespace = "default"
+        info_tool.method_name = "get_info"
+        info_tool.description = "Return a sample info dict."
+        info_tool.parameters = {"type": "object", "properties": {}}
+        info_tool.callable = get_info
+        info_tool.is_async = False
+
+        mock_registry._tools = {"get_info": info_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("get_info", {})
+            assert result.isError is False
+            parsed = json.loads(result.content[0].text)
+            assert parsed == {"status": "ok", "count": 42}
+
+    @pytest.mark.asyncio
+    async def test_str_result_direct_string(self, mock_registry: MagicMock) -> None:
+        """A str result should be returned as-is."""
+        greet_tool = MagicMock()
+        greet_tool.name = "greet"
+        greet_tool.namespace = "default"
+        greet_tool.method_name = "greet"
+        greet_tool.description = "Return a greeting string."
+        greet_tool.parameters = {"type": "object", "properties": {}}
+        greet_tool.callable = greet
+        greet_tool.is_async = False
+
+        mock_registry._tools = {"greet": greet_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("greet", {"name": "World"})
+            assert result.isError is False
+            assert result.content[0].text == "Hello, World!"
+
+    @pytest.mark.asyncio
+    async def test_int_result_str_conversion(self, mock_registry: MagicMock) -> None:
+        """An int result should be converted via str()."""
+        answer_tool = MagicMock()
+        answer_tool.name = "get_answer"
+        answer_tool.namespace = "default"
+        answer_tool.method_name = "get_answer"
+        answer_tool.description = "Return the answer to everything."
+        answer_tool.parameters = {"type": "object", "properties": {}}
+        answer_tool.callable = get_answer
+        answer_tool.is_async = False
+
+        mock_registry._tools = {"get_answer": answer_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("get_answer", {})
+            assert result.isError is False
+            assert result.content[0].text == "42"
+
+    @pytest.mark.asyncio
+    async def test_float_result_str_conversion(self, mock_registry: MagicMock) -> None:
+        """A float result should be converted via str()."""
+        pi_tool = MagicMock()
+        pi_tool.name = "get_pi"
+        pi_tool.namespace = "default"
+        pi_tool.method_name = "get_pi"
+        pi_tool.description = "Return the value of pi."
+        pi_tool.parameters = {"type": "object", "properties": {}}
+        pi_tool.callable = get_pi
+        pi_tool.is_async = False
+
+        mock_registry._tools = {"get_pi": pi_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("get_pi", {})
+            assert result.isError is False
+            assert result.content[0].text == "3.14159"
+
+    @pytest.mark.asyncio
+    async def test_list_result_json_serialized(self, mock_registry: MagicMock) -> None:
+        """A list result should be JSON-serialized."""
+
+        def get_items() -> list:
+            """Return a sample list."""
+            return [1, "two", 3.0]
+
+        items_tool = MagicMock()
+        items_tool.name = "get_items"
+        items_tool.namespace = "default"
+        items_tool.method_name = "get_items"
+        items_tool.description = "Return a sample list."
+        items_tool.parameters = {"type": "object", "properties": {}}
+        items_tool.callable = get_items
+        items_tool.is_async = False
+
+        mock_registry._tools = {"get_items": items_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("get_items", {})
+            assert result.isError is False
+            parsed = json.loads(result.content[0].text)
+            assert parsed == [1, "two", 3.0]
+
+
+# ---------------------------------------------------------------------------
+# 7. Exception handling tests
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionHandling:
+    """Tests for exception handling in call_tool."""
+
+    @pytest.mark.asyncio
+    async def test_tool_execution_error_returns_error(
+        self, mock_registry: MagicMock
+    ) -> None:
+        """When a tool raises an exception, it should return isError=True."""
+        failing = MagicMock()
+        failing.name = "failing_tool"
+        failing.namespace = "default"
+        failing.method_name = "failing_tool"
+        failing.description = "A tool that always raises an exception."
+        failing.parameters = {"type": "object", "properties": {}}
+        failing.callable = failing_tool
+        failing.is_async = False
+
+        mock_registry._tools = {"failing_tool": failing}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("failing_tool", {})
+            assert result.isError is True
+            assert "intentional error for testing" in result.content[0].text


### PR DESCRIPTION
## Summary
Migrate MCP adapter functionality from toolregistry-hub to toolregistry-server with RouteTable integration.

## Changes
- **mcp/adapter.py**: Core MCP adapter using low-level Server API
  - `route_table_to_mcp_server()`: Convert RouteTable to MCP Server
  - Dynamic tool listing based on enabled state
  - Runtime enable/disable checks in call_tool handler
  - Result serialization (str, dict, list, Pydantic models)

- **mcp/server.py**: Transport runner functions
  - `run_stdio()`: stdio transport for local execution
  - `run_sse()`: SSE transport for web clients
  - `run_streamable_http()`: Streamable HTTP transport (recommended for production)

- **mcp/__init__.py**: Public API exports
  - `create_mcp_server()`: Alias for route_table_to_mcp_server
  - All transport runner functions

- **tests/test_mcp_adapter.py**: Comprehensive unit tests (21 tests)
  - Server creation tests
  - list_tools handler tests
  - Enable/disable dynamic reflection tests
  - call_tool handler tests
  - Sync/async tool execution tests
  - Result serialization tests
  - Exception handling tests

## Design Decisions
- Use low-level Server API instead of FastMCP for direct JSON Schema pass-through
- RouteTable provides single source of truth for tool state
- No drift between RouteTable and MCP tool listing

Closes #4