### PR TITLE
feat(openapi): add ETag support for cache validation

### DIFF
--- a/src/toolregistry_server/openapi/__init__.py
+++ b/src/toolregistry_server/openapi/__init__.py
@@ -8,6 +8,8 @@ Main Components:
     - create_openapi_app: Create a FastAPI application from a RouteTable
     - route_table_to_router: Convert a RouteTable to a FastAPI router
     - setup_dynamic_openapi: Configure dynamic OpenAPI schema generation
+    - ETagMiddleware: Middleware for ETag-based cache validation
+    - add_tools_endpoint: Add /tools endpoint for listing available tools
 
 Example:
     >>> from toolregistry import ToolRegistry
@@ -39,6 +41,7 @@ def create_openapi_app(
     version: str = "1.0.0",
     description: str = "OpenAPI server for ToolRegistry tools",
     dependencies: "Sequence[Any] | None" = None,
+    enable_etag: bool = True,
 ) -> "FastAPI":
     """Create a FastAPI application from a RouteTable.
 
@@ -48,9 +51,15 @@ def create_openapi_app(
         version: API version for OpenAPI schema.
         description: API description for OpenAPI schema.
         dependencies: Optional list of global dependencies (e.g., authentication).
+        enable_etag: Whether to enable ETag middleware for cache validation.
+            Defaults to True.
 
     Returns:
-        A configured FastAPI application.
+        A configured FastAPI application with:
+        - Tool routes from the RouteTable
+        - /tools endpoint for listing available tools
+        - ETag middleware for cache validation (if enabled)
+        - Dynamic OpenAPI schema that filters disabled tools
 
     Raises:
         ImportError: If FastAPI is not installed.
@@ -63,7 +72,12 @@ def create_openapi_app(
             "Install with: pip install toolregistry-server[openapi]"
         ) from e
 
-    from .adapter import route_table_to_router, setup_dynamic_openapi
+    from .adapter import (
+        add_tools_endpoint,
+        route_table_to_router,
+        setup_dynamic_openapi,
+    )
+    from .middleware import add_etag_middleware
 
     # Create app with optional global dependencies
     if dependencies:
@@ -79,6 +93,13 @@ def create_openapi_app(
             version=version,
             description=description,
         )
+
+    # Add ETag middleware for cache validation
+    if enable_etag:
+        add_etag_middleware(app, route_table)
+
+    # Add /tools endpoint for listing available tools
+    add_tools_endpoint(app, route_table)
 
     # Add routes from route table
     router = route_table_to_router(route_table)

--- a/src/toolregistry_server/openapi/adapter.py
+++ b/src/toolregistry_server/openapi/adapter.py
@@ -269,6 +269,80 @@ def route_table_to_router(
 
 
 # ---------------------------------------------------------------------------
+# Tools list endpoint
+# ---------------------------------------------------------------------------
+
+
+def add_tools_endpoint(app: "FastAPI", route_table: RouteTable) -> None:  # noqa: F821
+    """Add a /tools endpoint that returns the list of available tools.
+
+    This endpoint supports ETag-based cache validation. The response includes
+    the current ETag in both the response body and headers.
+
+    Args:
+        app: The FastAPI application instance.
+        route_table: The RouteTable to query for tools.
+
+    Example:
+        >>> from fastapi import FastAPI
+        >>> from toolregistry_server import RouteTable
+        >>> from toolregistry_server.openapi.adapter import add_tools_endpoint
+        >>>
+        >>> app = FastAPI()
+        >>> route_table = RouteTable(registry)
+        >>> add_tools_endpoint(app, route_table)
+    """
+    try:
+        from fastapi import Request
+        from fastapi.responses import JSONResponse
+    except ImportError as e:
+        raise ImportError(
+            "FastAPI is required for OpenAPI support. "
+            "Install with: pip install toolregistry-server[openapi]"
+        ) from e
+
+    @app.get("/tools", tags=["meta"])
+    async def list_tools(request: Request) -> JSONResponse:
+        """List all available tools with their metadata.
+
+        Returns a JSON object containing:
+        - tools: List of tool information (name, namespace, method, path, description)
+        - etag: Current ETag for cache validation
+
+        Supports conditional requests via If-None-Match header.
+        Returns 304 Not Modified if the ETag matches.
+        """
+        # Check If-None-Match header
+        if_none_match = request.headers.get("If-None-Match")
+        current_etag = route_table.etag
+
+        if if_none_match and if_none_match == current_etag:
+            return JSONResponse(
+                content=None,
+                status_code=304,
+                headers={"ETag": current_etag},
+            )
+
+        # Build tools list
+        tools = []
+        for route in route_table.list_routes(enabled_only=True):
+            tools.append(
+                {
+                    "name": route.tool_name,
+                    "namespace": route.namespace,
+                    "method": route.method_name,
+                    "path": route.path,
+                    "description": route.description,
+                }
+            )
+
+        return JSONResponse(
+            content={"tools": tools, "etag": current_etag},
+            headers={"ETag": current_etag},
+        )
+
+
+# ---------------------------------------------------------------------------
 # Dynamic OpenAPI schema generation
 # ---------------------------------------------------------------------------
 

--- a/src/toolregistry_server/openapi/middleware.py
+++ b/src/toolregistry_server/openapi/middleware.py
@@ -1,0 +1,135 @@
+"""
+ETag middleware for OpenAPI server.
+
+This module provides middleware for ETag-based cache validation,
+supporting conditional requests with If-None-Match headers.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..route_table import RouteTable
+
+
+class ETagMiddleware:
+    """Middleware for ETag-based cache validation.
+
+    This middleware intercepts requests and checks the If-None-Match header
+    against the current ETag from the RouteTable. If they match, it returns
+    a 304 Not Modified response. Otherwise, it adds the current ETag to the
+    response headers.
+
+    The middleware only applies ETag handling to GET requests on specific
+    paths (e.g., /tools, /openapi.json) to avoid interfering with tool
+    execution endpoints.
+
+    Example:
+        >>> from fastapi import FastAPI
+        >>> from toolregistry_server import RouteTable
+        >>> from toolregistry_server.openapi.middleware import ETagMiddleware
+        >>>
+        >>> app = FastAPI()
+        >>> route_table = RouteTable(registry)
+        >>> app.add_middleware(ETagMiddleware, route_table=route_table)
+
+    Attributes:
+        app: The ASGI application to wrap.
+        route_table: The RouteTable instance for ETag generation.
+        etag_paths: Set of paths that should have ETag handling.
+    """
+
+    # Paths that should have ETag handling applied
+    ETAG_PATHS = frozenset({"/tools", "/openapi.json"})
+
+    def __init__(self, app: "ASGIApp", route_table: "RouteTable") -> None:  # noqa: F821
+        """Initialize the ETag middleware.
+
+        Args:
+            app: The ASGI application to wrap.
+            route_table: The RouteTable instance for ETag generation.
+        """
+        self.app = app
+        self.route_table = route_table
+
+    async def __call__(
+        self,
+        scope: "Scope",  # noqa: F821
+        receive: "Receive",  # noqa: F821
+        send: "Send",  # noqa: F821
+    ) -> None:
+        """Process the request through the middleware.
+
+        Args:
+            scope: The ASGI scope dictionary.
+            receive: The ASGI receive callable.
+            send: The ASGI send callable.
+        """
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        method = scope.get("method", "")
+
+        # Only apply ETag handling to GET requests on specific paths
+        if method != "GET" or path not in self.ETAG_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        # Extract If-None-Match header
+        headers = dict(scope.get("headers", []))
+        if_none_match = headers.get(b"if-none-match", b"").decode("utf-8")
+
+        current_etag = self.route_table.etag
+
+        # If ETag matches, return 304 Not Modified
+        if if_none_match and if_none_match == current_etag:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 304,
+                    "headers": [
+                        (b"etag", current_etag.encode("utf-8")),
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+            return
+
+        # Otherwise, process the request and add ETag to response
+        async def send_with_etag(message: dict) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                # Add ETag header if not already present
+                header_names = {h[0].lower() for h in headers}
+                if b"etag" not in header_names:
+                    headers.append((b"etag", current_etag.encode("utf-8")))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_etag)
+
+
+def add_etag_middleware(app: "FastAPI", route_table: "RouteTable") -> None:  # noqa: F821
+    """Add ETag middleware to a FastAPI application.
+
+    This is a convenience function to add the ETagMiddleware to a FastAPI
+    application with the correct configuration.
+
+    Args:
+        app: The FastAPI application instance.
+        route_table: The RouteTable instance for ETag generation.
+
+    Example:
+        >>> from fastapi import FastAPI
+        >>> from toolregistry_server import RouteTable
+        >>> from toolregistry_server.openapi.middleware import add_etag_middleware
+        >>>
+        >>> app = FastAPI()
+        >>> route_table = RouteTable(registry)
+        >>> add_etag_middleware(app, route_table)
+    """
+    app.add_middleware(ETagMiddleware, route_table=route_table)
+
+
+__all__ = ["ETagMiddleware", "add_etag_middleware"]

--- a/tests/test_openapi_adapter.py
+++ b/tests/test_openapi_adapter.py
@@ -8,9 +8,11 @@ from toolregistry_server.openapi import create_openapi_app
 from toolregistry_server.openapi.adapter import (
     _resolve_type,
     _schema_to_pydantic,
+    add_tools_endpoint,
     route_table_to_router,
     setup_dynamic_openapi,
 )
+from toolregistry_server.openapi.middleware import add_etag_middleware
 
 # ============== Fixtures ==============
 
@@ -302,3 +304,231 @@ class TestDynamicOpenAPI:
         response = client.get("/openapi.json")
         paths = response.json()["paths"]
         assert "/tools/default/greet" in paths
+
+
+# ============== Tools Endpoint Tests ==============
+
+
+class TestToolsEndpoint:
+    """Tests for the /tools endpoint."""
+
+    def test_tools_endpoint_returns_list(self, route_table: RouteTable):
+        """Test that /tools endpoint returns a list of tools."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        response = client.get("/tools")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "tools" in data
+        assert "etag" in data
+        assert isinstance(data["tools"], list)
+        assert len(data["tools"]) == 3  # greet, add, async_greet
+
+    def test_tools_endpoint_tool_structure(self, route_table: RouteTable):
+        """Test that each tool has the expected structure."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        response = client.get("/tools")
+        data = response.json()
+
+        for tool in data["tools"]:
+            assert "name" in tool
+            assert "namespace" in tool
+            assert "method" in tool
+            assert "path" in tool
+            assert "description" in tool
+
+    def test_tools_endpoint_etag_header(self, route_table: RouteTable):
+        """Test that /tools endpoint returns ETag header."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        response = client.get("/tools")
+        assert response.status_code == 200
+        assert "ETag" in response.headers
+
+        # ETag in header should match etag in body
+        data = response.json()
+        assert response.headers["ETag"] == data["etag"]
+
+    def test_tools_endpoint_conditional_request(self, route_table: RouteTable):
+        """Test that /tools endpoint supports If-None-Match."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        # First request to get ETag
+        response1 = client.get("/tools")
+        assert response1.status_code == 200
+        etag = response1.headers["ETag"]
+
+        # Second request with If-None-Match
+        response2 = client.get("/tools", headers={"If-None-Match": etag})
+        assert response2.status_code == 304
+
+    def test_tools_endpoint_etag_changes_on_disable(self, route_table: RouteTable):
+        """Test that ETag changes when a tool is disabled."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        # Get initial ETag
+        response1 = client.get("/tools")
+        etag1 = response1.headers["ETag"]
+
+        # Disable a tool
+        route_table.disable("add")
+
+        # Get new ETag
+        response2 = client.get("/tools")
+        etag2 = response2.headers["ETag"]
+
+        # ETags should be different
+        assert etag1 != etag2
+
+    def test_tools_endpoint_excludes_disabled(self, route_table: RouteTable):
+        """Test that /tools endpoint excludes disabled tools."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table)
+        client = TestClient(app)
+
+        # Initially all tools visible
+        response1 = client.get("/tools")
+        tools1 = response1.json()["tools"]
+        tool_names1 = {t["name"] for t in tools1}
+        assert "add" in tool_names1
+
+        # Disable a tool
+        route_table.disable("add")
+
+        # Tool should be excluded
+        response2 = client.get("/tools")
+        tools2 = response2.json()["tools"]
+        tool_names2 = {t["name"] for t in tools2}
+        assert "add" not in tool_names2
+
+
+# ============== ETag Middleware Tests ==============
+
+
+class TestETagMiddleware:
+    """Tests for ETag middleware."""
+
+    def test_etag_middleware_adds_header(self, route_table: RouteTable):
+        """Test that ETag middleware adds ETag header to responses."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table, enable_etag=True)
+        client = TestClient(app)
+
+        response = client.get("/tools")
+        assert "ETag" in response.headers
+
+    def test_etag_middleware_304_on_match(self, route_table: RouteTable):
+        """Test that middleware returns 304 when ETag matches."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table, enable_etag=True)
+        client = TestClient(app)
+
+        # Get ETag
+        response1 = client.get("/tools")
+        etag = response1.headers["ETag"]
+
+        # Request with matching If-None-Match
+        response2 = client.get("/tools", headers={"If-None-Match": etag})
+        assert response2.status_code == 304
+
+    def test_etag_middleware_200_on_mismatch(self, route_table: RouteTable):
+        """Test that middleware returns 200 when ETag doesn't match."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table, enable_etag=True)
+        client = TestClient(app)
+
+        # Request with non-matching If-None-Match
+        response = client.get("/tools", headers={"If-None-Match": '"invalid"'})
+        assert response.status_code == 200
+
+    def test_etag_middleware_disabled(self, route_table: RouteTable):
+        """Test that ETag middleware can be disabled."""
+        from fastapi.testclient import TestClient
+
+        # Create app without ETag middleware
+        app = create_openapi_app(route_table, enable_etag=False)
+        client = TestClient(app)
+
+        # /tools endpoint still adds ETag header (it's built into the endpoint)
+        response = client.get("/tools")
+        assert response.status_code == 200
+        # The endpoint itself adds ETag, but middleware doesn't intercept
+
+    def test_etag_middleware_only_on_get(self, route_table: RouteTable):
+        """Test that ETag middleware only applies to GET requests."""
+        from fastapi.testclient import TestClient
+
+        app = create_openapi_app(route_table, enable_etag=True)
+        client = TestClient(app)
+
+        # POST request should not be affected by ETag middleware
+        response = client.post(
+            "/tools/default/add",
+            json={"a": 1, "b": 2},
+            headers={"If-None-Match": route_table.etag},
+        )
+        # Should execute normally, not return 304
+        assert response.status_code == 200
+        assert response.json() == 3
+
+
+class TestAddToolsEndpoint:
+    """Tests for add_tools_endpoint function."""
+
+    def test_add_tools_endpoint_to_app(self, route_table: RouteTable):
+        """Test adding /tools endpoint to an existing app."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        add_tools_endpoint(app, route_table)
+
+        client = TestClient(app)
+        response = client.get("/tools")
+        assert response.status_code == 200
+        assert "tools" in response.json()
+
+
+class TestAddETagMiddleware:
+    """Tests for add_etag_middleware function."""
+
+    def test_add_etag_middleware_to_app(self, route_table: RouteTable):
+        """Test adding ETag middleware to an existing app."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        add_tools_endpoint(app, route_table)
+        add_etag_middleware(app, route_table)
+
+        client = TestClient(app)
+
+        # Get ETag
+        response1 = client.get("/tools")
+        etag = response1.headers.get("ETag")
+        assert etag is not None
+
+        # Conditional request
+        response2 = client.get("/tools", headers={"If-None-Match": etag})
+        assert response2.status_code == 304


### PR DESCRIPTION
## Summary

This PR implements ETag support for the OpenAPI server, enabling cache validation and conditional requests.

## Changes

### New Features

1. **ETag Middleware** (`middleware.py`)
   - Intercepts GET requests on `/tools` and `/openapi.json` paths
   - Checks `If-None-Match` header against current ETag
   - Returns 304 Not Modified when ETag matches
   - Adds ETag header to responses

2. **/tools Endpoint** (`adapter.py`)
   - New endpoint returning list of available tools
   - Response format: `{"tools": [...], "etag": "..."}`
   - Each tool includes: name, namespace, method, path, description
   - Built-in support for conditional requests

3. **Integration** (`__init__.py`)
   - Updated `create_openapi_app` with `enable_etag` parameter (default: True)
   - Automatic middleware and endpoint registration

### Tests

Added 13 new tests covering:
- /tools endpoint functionality
- ETag header generation
- Conditional request handling (304 responses)
- ETag changes on tool state changes
- Middleware enable/disable

## Verification

All 93 tests pass:
```
tests/test_openapi_adapter.py: 34 passed
tests/test_route_table.py: 19 passed
tests/test_mcp_adapter.py: 21 passed
tests/test_auth.py: 19 passed
```

Closes #5