### PR TITLE
feat(cli): implement CLI with subcommands for OpenAPI and MCP servers

### DIFF
--- a/src/toolregistry_server/cli/__init__.py
+++ b/src/toolregistry_server/cli/__init__.py
@@ -1,22 +1,26 @@
 """
 Command-line interface for ToolRegistry Server.
 
-This module provides the CLI entry point for running ToolRegistry servers.
+This module provides the CLI entry point for running ToolRegistry servers
+with support for both OpenAPI and MCP protocols.
 
 Usage:
-    toolregistry-server --mode openapi --port 8000
-    toolregistry-server --mode mcp
+    toolregistry-server openapi [OPTIONS]
+    toolregistry-server mcp [OPTIONS]
     toolregistry-server --help
 
 Example:
     # Start OpenAPI server on port 8000
-    $ toolregistry-server --mode openapi --port 8000
+    $ toolregistry-server openapi --port 8000
 
-    # Start MCP server (stdio mode)
-    $ toolregistry-server --mode mcp
+    # Start MCP server with stdio transport
+    $ toolregistry-server mcp --transport stdio
 
-    # With authentication
-    $ toolregistry-server --mode openapi --auth-token "secret"
+    # Start MCP server with SSE transport
+    $ toolregistry-server mcp --transport sse --port 8000
+
+    # With configuration file
+    $ toolregistry-server openapi --config tools.jsonc
 """
 
 import argparse
@@ -28,7 +32,7 @@ def create_parser() -> argparse.ArgumentParser:
     """Create the argument parser for the CLI.
 
     Returns:
-        Configured ArgumentParser instance.
+        Configured ArgumentParser instance with subcommands.
     """
     parser = argparse.ArgumentParser(
         prog="toolregistry-server",
@@ -36,44 +40,107 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--mode",
-        choices=["openapi", "mcp"],
-        default="openapi",
-        help="Server mode: 'openapi' for REST API, 'mcp' for Model Context Protocol",
-    )
-
-    parser.add_argument(
-        "--host",
-        default="0.0.0.0",
-        help="Host to bind to (OpenAPI mode only, default: 0.0.0.0)",
-    )
-
-    parser.add_argument(
-        "--port",
-        type=int,
-        default=8000,
-        help="Port to listen on (OpenAPI mode only, default: 8000)",
-    )
-
-    parser.add_argument(
-        "--auth-token",
-        dest="auth_token",
-        help="Bearer token for authentication (optional)",
-    )
-
-    parser.add_argument(
-        "--auth-file",
-        dest="auth_file",
-        help="File containing authentication tokens, one per line (optional)",
-    )
-
-    parser.add_argument(
         "--version",
+        "-V",
         action="store_true",
         help="Show version and exit",
     )
 
+    # Create subparsers for openapi and mcp commands
+    subparsers = parser.add_subparsers(
+        dest="command",
+        title="commands",
+        description="Available server modes",
+        metavar="{openapi,mcp}",
+    )
+
+    # OpenAPI subcommand
+    openapi_parser = subparsers.add_parser(
+        "openapi",
+        help="Start OpenAPI (REST) server",
+        description="Start an OpenAPI server exposing tools as REST endpoints",
+    )
+    _add_openapi_arguments(openapi_parser)
+
+    # MCP subcommand
+    mcp_parser = subparsers.add_parser(
+        "mcp",
+        help="Start MCP server",
+        description="Start an MCP server for LLM tool integration",
+    )
+    _add_mcp_arguments(mcp_parser)
+
     return parser
+
+
+def _add_openapi_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add OpenAPI-specific arguments to the parser.
+
+    Args:
+        parser: The ArgumentParser to add arguments to.
+    """
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Host to bind the server to (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind the server to (default: 8000)",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to a JSON/JSONC configuration file for tools",
+    )
+    parser.add_argument(
+        "--tokens",
+        type=str,
+        default=None,
+        help="Path to a file containing authentication tokens (one per line)",
+    )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable auto-reload for development mode",
+    )
+
+
+def _add_mcp_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add MCP-specific arguments to the parser.
+
+    Args:
+        parser: The ArgumentParser to add arguments to.
+    """
+    parser.add_argument(
+        "--transport",
+        type=str,
+        choices=["stdio", "sse", "streamable-http"],
+        default="stdio",
+        help="Transport type: stdio, sse, or streamable-http (default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Host for SSE/HTTP transport (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for SSE/HTTP transport (default: 8000)",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to a JSON/JSONC configuration file for tools",
+    )
 
 
 def main(args: list[str] | None = None) -> NoReturn | None:
@@ -88,24 +155,38 @@ def main(args: list[str] | None = None) -> NoReturn | None:
     parser = create_parser()
     parsed = parser.parse_args(args)
 
+    # Handle version flag
     if parsed.version:
         from toolregistry_server import __version__
 
         print(f"toolregistry-server {__version__}")
         sys.exit(0)
 
-    # TODO: Implement server startup logic
-    # This is a skeleton implementation - full implementation will be
-    # migrated from toolregistry-hub's cli.py
+    # If no command specified, show help
+    if parsed.command is None:
+        parser.print_help()
+        sys.exit(0)
 
-    if parsed.mode == "openapi":
-        print(f"Starting OpenAPI server on {parsed.host}:{parsed.port}")
-        print("Note: This is a skeleton implementation.")
-        print("Full implementation will be available after migration.")
-    elif parsed.mode == "mcp":
-        print("Starting MCP server (stdio mode)")
-        print("Note: This is a skeleton implementation.")
-        print("Full implementation will be available after migration.")
+    # Dispatch to appropriate command handler
+    if parsed.command == "openapi":
+        from .openapi import run_openapi_server
+
+        run_openapi_server(
+            host=parsed.host,
+            port=parsed.port,
+            config_path=parsed.config,
+            tokens_path=parsed.tokens,
+            reload=parsed.reload,
+        )
+    elif parsed.command == "mcp":
+        from .mcp import run_mcp_server
+
+        run_mcp_server(
+            transport=parsed.transport,
+            host=parsed.host,
+            port=parsed.port,
+            config_path=parsed.config,
+        )
 
     return None
 

--- a/src/toolregistry_server/cli/mcp.py
+++ b/src/toolregistry_server/cli/mcp.py
@@ -1,0 +1,101 @@
+"""
+MCP server startup module.
+
+This module provides functions to start an MCP server from the CLI.
+"""
+
+import asyncio
+import sys
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from toolregistry import ToolRegistry
+
+
+def create_registry_from_config(config: dict | None) -> "ToolRegistry":
+    """Create a ToolRegistry from configuration.
+
+    Args:
+        config: Configuration dictionary, or None for empty registry.
+
+    Returns:
+        Configured ToolRegistry instance.
+    """
+    # Import the shared implementation from openapi module
+    from .openapi import create_registry_from_config as _create_registry
+
+    return _create_registry(config)
+
+
+def load_config(config_path: str | None) -> dict | None:
+    """Load configuration from a JSON/JSONC file.
+
+    Args:
+        config_path: Path to the configuration file, or None.
+
+    Returns:
+        Parsed configuration dictionary, or None if no config specified.
+    """
+    # Import the shared implementation from openapi module
+    from .openapi import load_config as _load_config
+
+    return _load_config(config_path)
+
+
+def run_mcp_server(
+    transport: str = "stdio",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    config_path: str | None = None,
+) -> None:
+    """Start the MCP server.
+
+    Args:
+        transport: Transport type: stdio, sse, or streamable-http.
+        host: Host for SSE/HTTP transport.
+        port: Port for SSE/HTTP transport.
+        config_path: Path to configuration file.
+    """
+    try:
+        from toolregistry_server import RouteTable
+        from toolregistry_server.mcp import route_table_to_mcp_server
+        from toolregistry_server.mcp.server import (
+            run_sse,
+            run_stdio,
+            run_streamable_http,
+        )
+    except ImportError as e:
+        logger.error(f"MCP server dependencies not installed: {e}")
+        logger.info("Install with: pip install toolregistry-server[mcp]")
+        sys.exit(1)
+
+    # Load configuration
+    config = load_config(config_path)
+
+    # Create registry from config
+    registry = create_registry_from_config(config)
+
+    # Create route table
+    route_table = RouteTable(registry)
+
+    # Create MCP server
+    mcp_server = route_table_to_mcp_server(route_table)
+
+    # Log startup info
+    logger.info(f"Starting MCP server with {transport} transport")
+    logger.info(f"Registered {len(route_table.list_routes())} tool(s)")
+
+    # Run the appropriate transport
+    if transport == "stdio":
+        asyncio.run(run_stdio(mcp_server))
+    elif transport == "sse":
+        logger.info(f"SSE endpoint: http://{host}:{port}/sse")
+        asyncio.run(run_sse(mcp_server, host=host, port=port))
+    elif transport == "streamable-http":
+        logger.info(f"HTTP endpoint: http://{host}:{port}/mcp")
+        asyncio.run(run_streamable_http(mcp_server, host=host, port=port))
+    else:
+        logger.error(f"Unknown transport type: {transport}")
+        sys.exit(1)

--- a/src/toolregistry_server/cli/openapi.py
+++ b/src/toolregistry_server/cli/openapi.py
@@ -1,0 +1,254 @@
+"""
+OpenAPI server startup module.
+
+This module provides functions to start an OpenAPI server from the CLI.
+"""
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from toolregistry import ToolRegistry
+
+
+def load_config(config_path: str | None) -> dict | None:
+    """Load configuration from a JSON/JSONC file.
+
+    Args:
+        config_path: Path to the configuration file, or None.
+
+    Returns:
+        Parsed configuration dictionary, or None if no config specified.
+
+    Raises:
+        SystemExit: If the config file cannot be loaded.
+    """
+    if config_path is None:
+        return None
+
+    path = Path(config_path)
+    if not path.exists():
+        logger.error(f"Configuration file not found: {config_path}")
+        sys.exit(1)
+
+    try:
+        import json
+
+        content = path.read_text(encoding="utf-8")
+
+        # Handle JSONC (JSON with comments) by stripping comments
+        lines = []
+        for line in content.splitlines():
+            stripped = line.strip()
+            # Skip full-line comments
+            if stripped.startswith("//"):
+                continue
+            # Remove inline comments (simple approach)
+            if "//" in line:
+                # Be careful not to remove // inside strings
+                # This is a simple heuristic that works for most cases
+                in_string = False
+                result = []
+                i = 0
+                while i < len(line):
+                    if line[i] == '"' and (i == 0 or line[i - 1] != "\\"):
+                        in_string = not in_string
+                    if not in_string and line[i : i + 2] == "//":
+                        break
+                    result.append(line[i])
+                    i += 1
+                lines.append("".join(result))
+            else:
+                lines.append(line)
+
+        clean_content = "\n".join(lines)
+        return json.loads(clean_content)
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON in configuration file: {e}")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Failed to load configuration file: {e}")
+        sys.exit(1)
+
+
+def load_tokens(tokens_path: str | None) -> list[str]:
+    """Load authentication tokens from a file.
+
+    Args:
+        tokens_path: Path to the tokens file, or None.
+
+    Returns:
+        List of tokens, or empty list if no file specified.
+
+    Raises:
+        SystemExit: If the tokens file cannot be loaded.
+    """
+    if tokens_path is None:
+        return []
+
+    path = Path(tokens_path)
+    if not path.exists():
+        logger.error(f"Tokens file not found: {tokens_path}")
+        sys.exit(1)
+
+    try:
+        content = path.read_text(encoding="utf-8")
+        tokens = []
+        for line in content.splitlines():
+            line = line.strip()
+            # Skip empty lines and comments
+            if line and not line.startswith("#"):
+                tokens.append(line)
+        return tokens
+    except Exception as e:
+        logger.error(f"Failed to load tokens file: {e}")
+        sys.exit(1)
+
+
+def create_registry_from_config(config: dict | None) -> "ToolRegistry":
+    """Create a ToolRegistry from configuration.
+
+    Args:
+        config: Configuration dictionary, or None for empty registry.
+
+    Returns:
+        Configured ToolRegistry instance.
+    """
+    from toolregistry import ToolRegistry
+
+    registry = ToolRegistry()
+
+    if config is None:
+        logger.info("No configuration provided, starting with empty registry")
+        return registry
+
+    # Process tools from config
+    tools = config.get("tools", [])
+    for tool_config in tools:
+        # Tool configuration format:
+        # {
+        #     "module": "module.path",
+        #     "class": "ClassName",  # optional
+        #     "enabled": true,       # optional, default true
+        #     "namespace": "ns"      # optional
+        # }
+        module_path = tool_config.get("module")
+        class_name = tool_config.get("class")
+        enabled = tool_config.get("enabled", True)
+        namespace = tool_config.get("namespace")
+
+        if not module_path:
+            logger.warning(f"Skipping tool config without module: {tool_config}")
+            continue
+
+        try:
+            import importlib
+
+            module = importlib.import_module(module_path)
+
+            if class_name:
+                # Register a class
+                cls = getattr(module, class_name)
+                instance = cls()
+                registry.register_from_class(instance, namespace=namespace)
+            else:
+                # Register all public functions from module
+                for name in dir(module):
+                    if not name.startswith("_"):
+                        obj = getattr(module, name)
+                        if callable(obj) and not isinstance(obj, type):
+                            registry.register(obj, namespace=namespace)
+
+            if not enabled:
+                # Disable tools from this module
+                for tool_name in list(registry._tools.keys()):
+                    if namespace and tool_name.startswith(f"{namespace}-"):
+                        registry.disable(tool_name, "Disabled in configuration")
+
+            logger.info(f"Loaded tools from {module_path}")
+        except Exception as e:
+            logger.warning(f"Failed to load tools from {module_path}: {e}")
+
+    return registry
+
+
+def run_openapi_server(
+    host: str = "0.0.0.0",
+    port: int = 8000,
+    config_path: str | None = None,
+    tokens_path: str | None = None,
+    reload: bool = False,
+) -> None:
+    """Start the OpenAPI server.
+
+    Args:
+        host: Host to bind the server to.
+        port: Port to bind the server to.
+        config_path: Path to configuration file.
+        tokens_path: Path to tokens file.
+        reload: Enable auto-reload for development.
+    """
+    try:
+        import uvicorn
+    except ImportError as e:
+        logger.error(f"OpenAPI server dependencies not installed: {e}")
+        logger.info("Install with: pip install toolregistry-server[openapi]")
+        sys.exit(1)
+
+    try:
+        from toolregistry_server import RouteTable
+        from toolregistry_server.openapi import create_openapi_app
+    except ImportError as e:
+        logger.error(f"Failed to import server components: {e}")
+        sys.exit(1)
+
+    # Load configuration
+    config = load_config(config_path)
+
+    # Create registry from config
+    registry = create_registry_from_config(config)
+
+    # Create route table
+    route_table = RouteTable(registry)
+
+    # Load tokens for authentication
+    tokens = load_tokens(tokens_path)
+
+    # Create dependencies for authentication if tokens are provided
+    dependencies = None
+    if tokens:
+        try:
+            from fastapi import Depends
+
+            from toolregistry_server.auth import (
+                BearerTokenAuth,
+                create_bearer_dependency,
+            )
+
+            auth = BearerTokenAuth(tokens=tokens)
+            dependencies = [Depends(create_bearer_dependency(auth))]
+            logger.info(f"Authentication enabled with {len(tokens)} token(s)")
+        except ImportError as e:
+            logger.warning(f"Failed to setup authentication: {e}")
+
+    # Create the FastAPI app
+    app = create_openapi_app(
+        route_table,
+        title="ToolRegistry Server",
+        version="1.0.0",
+        description="OpenAPI server for ToolRegistry tools",
+        dependencies=dependencies,
+    )
+
+    # Log startup info
+    logger.info(f"Starting OpenAPI server on {host}:{port}")
+    logger.info(f"Registered {len(route_table.list_routes())} tool(s)")
+
+    # Run the server
+    if reload:
+        logger.warning("Reload mode is not fully supported with dynamic configuration")
+
+    uvicorn.run(app, host=host, port=port, reload=reload)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,281 @@
+"""Tests for the CLI module."""
+
+import argparse
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from toolregistry_server.cli import create_parser, main
+
+
+class TestCreateParser:
+    """Tests for create_parser function."""
+
+    def test_parser_creation(self):
+        """Test that parser is created successfully."""
+        parser = create_parser()
+        assert isinstance(parser, argparse.ArgumentParser)
+        assert parser.prog == "toolregistry-server"
+
+    def test_version_flag(self):
+        """Test --version flag is recognized."""
+        parser = create_parser()
+        args = parser.parse_args(["--version"])
+        assert args.version is True
+
+    def test_version_short_flag(self):
+        """Test -V flag is recognized."""
+        parser = create_parser()
+        args = parser.parse_args(["-V"])
+        assert args.version is True
+
+    def test_no_command(self):
+        """Test parsing with no command."""
+        parser = create_parser()
+        args = parser.parse_args([])
+        assert args.command is None
+
+    def test_openapi_command(self):
+        """Test openapi subcommand parsing."""
+        parser = create_parser()
+        args = parser.parse_args(["openapi"])
+        assert args.command == "openapi"
+        assert args.host == "0.0.0.0"
+        assert args.port == 8000
+        assert args.config is None
+        assert args.tokens is None
+        assert args.reload is False
+
+    def test_openapi_with_options(self):
+        """Test openapi subcommand with all options."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "openapi",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "9000",
+                "--config",
+                "tools.jsonc",
+                "--tokens",
+                "tokens.txt",
+                "--reload",
+            ]
+        )
+        assert args.command == "openapi"
+        assert args.host == "127.0.0.1"
+        assert args.port == 9000
+        assert args.config == "tools.jsonc"
+        assert args.tokens == "tokens.txt"
+        assert args.reload is True
+
+    def test_mcp_command(self):
+        """Test mcp subcommand parsing."""
+        parser = create_parser()
+        args = parser.parse_args(["mcp"])
+        assert args.command == "mcp"
+        assert args.transport == "stdio"
+        assert args.host == "127.0.0.1"
+        assert args.port == 8000
+        assert args.config is None
+
+    def test_mcp_with_options(self):
+        """Test mcp subcommand with all options."""
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "mcp",
+                "--transport",
+                "sse",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "9000",
+                "--config",
+                "tools.jsonc",
+            ]
+        )
+        assert args.command == "mcp"
+        assert args.transport == "sse"
+        assert args.host == "0.0.0.0"
+        assert args.port == 9000
+        assert args.config == "tools.jsonc"
+
+    def test_mcp_transport_choices(self):
+        """Test mcp transport choices."""
+        parser = create_parser()
+
+        # Valid choices
+        for transport in ["stdio", "sse", "streamable-http"]:
+            args = parser.parse_args(["mcp", "--transport", transport])
+            assert args.transport == transport
+
+        # Invalid choice
+        with pytest.raises(SystemExit):
+            parser.parse_args(["mcp", "--transport", "invalid"])
+
+
+class TestMain:
+    """Tests for main function."""
+
+    def test_version_output(self, capsys):
+        """Test version output."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        assert exc_info.value.code == 0
+
+        captured = capsys.readouterr()
+        assert "toolregistry-server" in captured.out
+
+    def test_no_command_shows_help(self, capsys):
+        """Test that no command shows help."""
+        with pytest.raises(SystemExit) as exc_info:
+            main([])
+        assert exc_info.value.code == 0
+
+    @patch("toolregistry_server.cli.openapi.run_openapi_server")
+    def test_openapi_command_dispatch(self, mock_run):
+        """Test openapi command dispatches correctly."""
+        main(["openapi", "--port", "9000"])
+        mock_run.assert_called_once_with(
+            host="0.0.0.0",
+            port=9000,
+            config_path=None,
+            tokens_path=None,
+            reload=False,
+        )
+
+    @patch("toolregistry_server.cli.mcp.run_mcp_server")
+    def test_mcp_command_dispatch(self, mock_run):
+        """Test mcp command dispatches correctly."""
+        main(["mcp", "--transport", "sse", "--port", "9000"])
+        mock_run.assert_called_once_with(
+            transport="sse",
+            host="127.0.0.1",
+            port=9000,
+            config_path=None,
+        )
+
+
+class TestLoadConfig:
+    """Tests for load_config function."""
+
+    def test_load_config_none(self):
+        """Test load_config with None path."""
+        from toolregistry_server.cli.openapi import load_config
+
+        result = load_config(None)
+        assert result is None
+
+    def test_load_config_not_found(self):
+        """Test load_config with non-existent file."""
+        from toolregistry_server.cli.openapi import load_config
+
+        with pytest.raises(SystemExit):
+            load_config("/nonexistent/path/config.json")
+
+    def test_load_config_valid_json(self):
+        """Test load_config with valid JSON file."""
+        from toolregistry_server.cli.openapi import load_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write('{"tools": []}')
+            f.flush()
+
+            result = load_config(f.name)
+            assert result == {"tools": []}
+
+            Path(f.name).unlink()
+
+    def test_load_config_jsonc_with_comments(self):
+        """Test load_config with JSONC file containing comments."""
+        from toolregistry_server.cli.openapi import load_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonc", delete=False) as f:
+            f.write("""
+            // This is a comment
+            {
+                "tools": []  // inline comment
+            }
+            """)
+            f.flush()
+
+            result = load_config(f.name)
+            assert result == {"tools": []}
+
+            Path(f.name).unlink()
+
+    def test_load_config_invalid_json(self):
+        """Test load_config with invalid JSON."""
+        from toolregistry_server.cli.openapi import load_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not valid json")
+            f.flush()
+
+            with pytest.raises(SystemExit):
+                load_config(f.name)
+
+            Path(f.name).unlink()
+
+
+class TestLoadTokens:
+    """Tests for load_tokens function."""
+
+    def test_load_tokens_none(self):
+        """Test load_tokens with None path."""
+        from toolregistry_server.cli.openapi import load_tokens
+
+        result = load_tokens(None)
+        assert result == []
+
+    def test_load_tokens_not_found(self):
+        """Test load_tokens with non-existent file."""
+        from toolregistry_server.cli.openapi import load_tokens
+
+        with pytest.raises(SystemExit):
+            load_tokens("/nonexistent/path/tokens.txt")
+
+    def test_load_tokens_valid_file(self):
+        """Test load_tokens with valid file."""
+        from toolregistry_server.cli.openapi import load_tokens
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("token1\ntoken2\n# comment\n\ntoken3")
+            f.flush()
+
+            result = load_tokens(f.name)
+            assert result == ["token1", "token2", "token3"]
+
+            Path(f.name).unlink()
+
+
+class TestCreateRegistryFromConfig:
+    """Tests for create_registry_from_config function."""
+
+    def test_create_registry_no_config(self):
+        """Test creating registry with no config."""
+        from toolregistry_server.cli.openapi import create_registry_from_config
+
+        registry = create_registry_from_config(None)
+        assert len(registry._tools) == 0
+
+    def test_create_registry_empty_tools(self):
+        """Test creating registry with empty tools list."""
+        from toolregistry_server.cli.openapi import create_registry_from_config
+
+        config = {"tools": []}
+        registry = create_registry_from_config(config)
+        assert len(registry._tools) == 0
+
+    def test_create_registry_invalid_tool_config(self):
+        """Test creating registry with invalid tool config (no module)."""
+        from toolregistry_server.cli.openapi import create_registry_from_config
+
+        config = {"tools": [{"class": "SomeClass"}]}
+        registry = create_registry_from_config(config)
+        # Should skip invalid config and continue
+        assert len(registry._tools) == 0


### PR DESCRIPTION
## Summary

Implement a full-featured CLI for toolregistry-server with subcommand support.

## Changes

### CLI Structure
- Refactored CLI to use subcommands: `openapi` and `mcp`
- Added `cli/openapi.py` for OpenAPI server startup logic
- Added `cli/mcp.py` for MCP server startup logic

### OpenAPI Command
```
toolregistry-server openapi [OPTIONS]
  --host HOST          Server address (default: 0.0.0.0)
  --port PORT          Server port (default: 8000)
  --config CONFIG      Configuration file path (JSON/JSONC)
  --tokens TOKENS      Token file path for authentication
  --reload             Enable hot reload for development
```

### MCP Command
```
toolregistry-server mcp [OPTIONS]
  --transport TYPE     Transport type: stdio, sse, streamable-http (default: stdio)
  --host HOST          SSE/HTTP server address
  --port PORT          SSE/HTTP server port
  --config CONFIG      Configuration file path (JSON/JSONC)
```

### Features
- JSON/JSONC configuration file support with comment stripping
- Token-based authentication for OpenAPI server
- Multiple MCP transport modes
- Comprehensive unit tests (24 tests, all passing)

## Testing
- All 24 unit tests pass
- Code passes ruff check and format

Closes #6