### PR TITLE
fix: MCP transport issues

### DIFF
--- a/src/toolregistry_server/cli/openapi.py
+++ b/src/toolregistry_server/cli/openapi.py
@@ -129,6 +129,13 @@ def create_registry_from_config(config: dict | None) -> "ToolRegistry":
     tools = config.get("tools", [])
     for tool_config in tools:
         # Tool configuration format:
+        # Option 1 - Full class path:
+        # {
+        #     "class": "module.path.ClassName",
+        #     "enabled": true,       # optional, default true
+        #     "namespace": "ns"      # optional
+        # }
+        # Option 2 - Separate module and class:
         # {
         #     "module": "module.path",
         #     "class": "ClassName",  # optional
@@ -139,6 +146,13 @@ def create_registry_from_config(config: dict | None) -> "ToolRegistry":
         class_name = tool_config.get("class")
         enabled = tool_config.get("enabled", True)
         namespace = tool_config.get("namespace")
+
+        # Support full class path in "class" field (e.g., "module.path.ClassName")
+        if not module_path and class_name and "." in class_name:
+            # Split the full class path into module and class name
+            parts = class_name.rsplit(".", 1)
+            module_path = parts[0]
+            class_name = parts[1]
 
         if not module_path:
             logger.warning(f"Skipping tool config without module: {tool_config}")
@@ -153,13 +167,18 @@ def create_registry_from_config(config: dict | None) -> "ToolRegistry":
                 # Register a class
                 cls = getattr(module, class_name)
                 instance = cls()
-                registry.register_from_class(instance, namespace=namespace)
+                # register_from_class uses with_namespace parameter
+                # If namespace is provided, use it; otherwise use False (no namespace)
+                registry.register_from_class(
+                    instance, with_namespace=namespace if namespace else False
+                )
             else:
                 # Register all public functions from module
                 for name in dir(module):
                     if not name.startswith("_"):
                         obj = getattr(module, name)
                         if callable(obj) and not isinstance(obj, type):
+                            # register uses namespace parameter
                             registry.register(obj, namespace=namespace)
 
             if not enabled:

--- a/src/toolregistry_server/mcp/server.py
+++ b/src/toolregistry_server/mcp/server.py
@@ -80,6 +80,8 @@ async def run_sse(
         import uvicorn
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
+        from starlette.requests import Request
+        from starlette.responses import Response
         from starlette.routing import Mount, Route
     except ImportError as e:
         raise ImportError(
@@ -92,13 +94,19 @@ async def run_sse(
     # Create SSE transport
     sse = SseServerTransport(f"{path}/messages/")
 
-    async def handle_sse(scope, receive, send):
-        async with sse.connect_sse(scope, receive, send) as streams:
+    # SSE endpoint handler - must accept Request and return Response
+    # See MCP SDK documentation for the correct pattern
+    async def handle_sse(request: Request) -> Response:
+        async with sse.connect_sse(
+            request.scope, request.receive, request._send
+        ) as streams:
             await server.run(
                 streams[0],
                 streams[1],
                 server.create_initialization_options(),
             )
+        # Return empty response to avoid NoneType error when client disconnects
+        return Response()
 
     # Create Starlette app
     routes = [
@@ -141,6 +149,7 @@ async def run_streamable_http(
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
         from starlette.applications import Starlette
         from starlette.routing import Route
+        from starlette.types import Receive, Scope, Send
     except ImportError as e:
         raise ImportError(
             "MCP SDK and Starlette are required for streamable HTTP transport. "
@@ -158,12 +167,22 @@ async def run_streamable_http(
         stateless=False,
     )
 
-    # Create ASGI handler
-    async def handle_mcp(scope, receive, send):
-        await session_manager.handle_request(scope, receive, send)
+    # Create ASGI application class for StreamableHTTP
+    # This is necessary because Starlette Route treats ASGI apps differently
+    # from regular endpoint functions - ASGI apps receive all HTTP methods
+    class StreamableHTTPASGIApp:
+        """ASGI application wrapper for StreamableHTTP session manager."""
+
+        def __init__(self, manager: StreamableHTTPSessionManager):
+            self.manager = manager
+
+        async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+            await self.manager.handle_request(scope, receive, send)
+
+    streamable_http_app = StreamableHTTPASGIApp(session_manager)
 
     # Create Starlette app with lifespan
-    routes = [Route(path, endpoint=handle_mcp)]
+    routes = [Route(path, endpoint=streamable_http_app)]
     app = Starlette(
         routes=routes,
         lifespan=lambda app: session_manager.run(),


### PR DESCRIPTION
## Summary
Fix MCP streamable-http and SSE transport issues that caused 405 errors with Cherry Studio MCP connector.

## Changes
- Fix streamable-http 405 error by using ASGI app wrapper instead of direct mount
- Fix SSE handler function signature to match expected interface
- Fix config parsing for full class paths (e.g., `module.ClassName`)

## Testing
Tested with Cherry Studio MCP connector - both streamable-http and SSE transports now work correctly.