### PR TITLE
feat: add customizable banner and fix disabled tools handling

### DIFF
--- a/src/toolregistry_server/cli/__init__.py
+++ b/src/toolregistry_server/cli/__init__.py
@@ -27,6 +27,80 @@ import argparse
 import sys
 from typing import NoReturn
 
+# Default ASCII art banner for ToolRegistry Server
+DEFAULT_BANNER_ART = """
+░▀█▀░█▀█░█▀█░█░░░█▀▄░█▀▀░█▀▀░▀█▀░█▀▀░▀█▀░█▀▄░█░█░░░░░█▀▀░█▀▀░█▀▄░█░█░█▀▀░█▀▄
+░░█░░█░█░█░█░█░░░█▀▄░█▀▀░█░█░░█░░▀▀█░░█░░█▀▄░░█░░▄▄▄░▀▀█░█▀▀░█▀▄░▀▄▀░█▀▀░█▀▄
+░░▀░░▀▀▀░▀▀▀░▀▀▀░▀░▀░▀▀▀░▀▀▀░▀▀▀░▀▀▀░░▀░░▀░▀░░▀░░░░░░▀▀▀░▀▀▀░▀░▀░░▀░░▀▀▀░▀░▀
+""".strip()
+
+
+def print_banner(
+    version: str | None = None,
+    banner_art: str | None = None,
+    extra_lines: list[str] | None = None,
+) -> None:
+    """Print the ToolRegistry Server banner with centered content and border.
+
+    This function can be used by downstream packages (e.g., toolregistry-hub)
+    to display a customized banner with their own version and art.
+
+    Args:
+        version: Version string to display. If None, uses toolregistry-server version.
+        banner_art: Custom ASCII art to display. If None, uses default banner.
+        extra_lines: Additional lines to display after the version (e.g., update info).
+    """
+    if version is None:
+        from toolregistry_server import __version__
+
+        version = __version__
+
+    if banner_art is None:
+        banner_art = DEFAULT_BANNER_ART
+
+    width = 80
+    border_char = "·"
+
+    # Split banner art into lines
+    art_lines = banner_art.split("\n")
+
+    # Build the banner
+    lines = []
+
+    # Top border
+    lines.append(border_char * width)
+
+    # Empty line
+    lines.append(f": {' ' * (width - 4)} :")
+
+    # Art lines - center each line
+    for line in art_lines:
+        centered = line.center(width - 4)
+        lines.append(f": {centered} :")
+
+    # Empty line
+    lines.append(f": {' ' * (width - 4)} :")
+
+    # Version information
+    version_line = f"Version {version}"
+    centered_version = version_line.center(width - 4)
+    lines.append(f": {centered_version} :")
+
+    # Extra lines (e.g., update available info)
+    if extra_lines:
+        for extra in extra_lines:
+            centered_extra = extra.center(width - 4)
+            lines.append(f": {centered_extra} :")
+
+    # Empty line
+    lines.append(f": {' ' * (width - 4)} :")
+
+    # Bottom border
+    lines.append(border_char * width)
+
+    # Print the banner
+    print("\n".join(lines))
+
 
 def create_parser() -> argparse.ArgumentParser:
     """Create the argument parser for the CLI.
@@ -44,6 +118,12 @@ def create_parser() -> argparse.ArgumentParser:
         "-V",
         action="store_true",
         help="Show version and exit",
+    )
+
+    parser.add_argument(
+        "--no-banner",
+        action="store_true",
+        help="Disable the startup banner",
     )
 
     # Create subparsers for openapi and mcp commands
@@ -167,6 +247,10 @@ def main(args: list[str] | None = None) -> NoReturn | None:
         parser.print_help()
         sys.exit(0)
 
+    # Print banner unless disabled
+    if not parsed.no_banner:
+        print_banner()
+
     # Dispatch to appropriate command handler
     if parsed.command == "openapi":
         from .openapi import run_openapi_server
@@ -194,4 +278,6 @@ def main(args: list[str] | None = None) -> NoReturn | None:
 __all__ = [
     "main",
     "create_parser",
+    "print_banner",
+    "DEFAULT_BANNER_ART",
 ]

--- a/src/toolregistry_server/cli/openapi.py
+++ b/src/toolregistry_server/cli/openapi.py
@@ -147,6 +147,11 @@ def create_registry_from_config(config: dict | None) -> "ToolRegistry":
         enabled = tool_config.get("enabled", True)
         namespace = tool_config.get("namespace")
 
+        # Skip disabled tools entirely - don't register them
+        if not enabled:
+            logger.info(f"Skipping disabled tool: {class_name or module_path}")
+            continue
+
         # Support full class path in "class" field (e.g., "module.path.ClassName")
         if not module_path and class_name and "." in class_name:
             # Split the full class path into module and class name
@@ -180,12 +185,6 @@ def create_registry_from_config(config: dict | None) -> "ToolRegistry":
                         if callable(obj) and not isinstance(obj, type):
                             # register uses namespace parameter
                             registry.register(obj, namespace=namespace)
-
-            if not enabled:
-                # Disable tools from this module
-                for tool_name in list(registry._tools.keys()):
-                    if namespace and tool_name.startswith(f"{namespace}-"):
-                        registry.disable(tool_name, "Disabled in configuration")
 
             logger.info(f"Loaded tools from {module_path}")
         except Exception as e:


### PR DESCRIPTION
## Summary
Add customizable banner infrastructure and fix disabled tools handling in config.

## Changes

### Banner Infrastructure
- Add `print_banner()` function with customizable parameters:
  - `version`: Custom version string
  - `banner_art`: Custom ASCII art
  - `extra_lines`: Additional lines (e.g., update notifications)
- Add `--no-banner` flag to disable startup banner
- Export `print_banner` and `DEFAULT_BANNER_ART` for downstream packages

### Disabled Tools Fix
- Fix disabled tools handling: skip registration entirely instead of registering then disabling
- This ensures disabled tools don't appear in the server at all

## Use Case
This allows downstream packages like toolregistry-hub to reuse the banner infrastructure with their own branding while maintaining consistent CLI behavior.