### PR TITLE
feat: MCP session context passthrough to tool handlers

### DIFF
--- a/src/toolregistry_server/__init__.py
+++ b/src/toolregistry_server/__init__.py
@@ -26,9 +26,11 @@ Example:
 __version__ = "0.1.2"
 
 from .route_table import RouteEntry, RouteTable
+from .session import SessionContext
 
 __all__ = [
     "__version__",
-    "RouteTable",
     "RouteEntry",
+    "RouteTable",
+    "SessionContext",
 ]

--- a/src/toolregistry_server/mcp/adapter.py
+++ b/src/toolregistry_server/mcp/adapter.py
@@ -11,6 +11,12 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from .._structlog import get_logger
+from ..session import (
+    SessionContext,
+    SessionManager,
+    session_context_var,
+    should_inject_session,
+)
 
 if TYPE_CHECKING:
     from mcp.server.lowlevel import Server
@@ -18,6 +24,55 @@ if TYPE_CHECKING:
     from ..route_table import RouteTable
 
 logger = get_logger()
+
+
+def _get_session_context(session_mgr: "SessionManager") -> SessionContext | None:
+    """Extract or create a SessionContext from the current MCP request.
+
+    Reads the MCP SDK's ``request_ctx`` contextvar to obtain the active
+    ``ServerSession`` and optional Starlette ``Request``, then delegates
+    to *session_mgr* for deduplication and lifecycle management.
+
+    Args:
+        session_mgr: The SessionManager that owns session state.
+
+    Returns:
+        A :class:`SessionContext`, or ``None`` when called outside an
+        MCP request context (should not happen in practice).
+    """
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+    except ImportError:
+        return None
+
+    mcp_ctx = request_ctx.get(None)
+    if mcp_ctx is None:
+        return None
+
+    mcp_session = mcp_ctx.session
+    session_key = id(mcp_session)
+
+    def _factory() -> SessionContext:
+        # Determine transport type from the request object
+        request = getattr(mcp_ctx, "request", None)
+        if request is None:
+            transport = "stdio"
+        else:
+            # Starlette Request — check for streamable-http header
+            headers = getattr(request, "headers", {})
+            transport = "streamable-http" if headers.get("mcp-session-id") else "sse"
+
+        return SessionContext(
+            session_id=SessionManager.new_session_id(),
+            transport=transport,
+        )
+
+    ctx = session_mgr.get_or_create(session_key, _factory)
+
+    # Register weak-reference finalizer for automatic cleanup
+    session_mgr.register_finalizer(mcp_session, session_key)
+
+    return ctx
 
 
 def _serialize_result(result: Any) -> str:
@@ -82,6 +137,7 @@ def route_table_to_mcp_server(
         ) from e
 
     server = Server(name)
+    session_mgr = SessionManager()
 
     @server.list_tools()
     async def handle_list_tools() -> list[MCPTool]:
@@ -134,7 +190,18 @@ def route_table_to_mcp_server(
                 )
             )
 
+        # --- Session context ---
+        session_ctx = _get_session_context(session_mgr)
+        token = None
+        if session_ctx is not None:
+            token = session_context_var.set(session_ctx)
+
         try:
+            # Resolve handler (possibly session-scoped)
+            handler = route.handler
+            if route.handler_factory and session_ctx:
+                handler = session_mgr.get_session_handler(session_ctx.session_id, route)
+
             # Validate and coerce parameters (e.g. string "8" → int 8)
             if isinstance(route.parameters_model, type) and issubclass(
                 route.parameters_model, BaseModel
@@ -142,11 +209,15 @@ def route_table_to_mcp_server(
                 model = route.parameters_model(**arguments)
                 arguments = model.model_dump_one_level()
 
+            # Inject session if handler requests it
+            if session_ctx and should_inject_session(handler):
+                arguments = {**arguments, "_session": session_ctx}
+
             # Execute the tool handler
             if route.is_async:
-                result = await route.handler(**arguments)
+                result = await handler(**arguments)
             else:
-                result = route.handler(**arguments)
+                result = handler(**arguments)
 
             # Serialize result to text
             text = _serialize_result(result)
@@ -158,14 +229,15 @@ def route_table_to_mcp_server(
             raise
         except Exception as e:
             logger.warning(f"call_tool '{name}': error - {e}")
-            # Return error as content; the SDK's handler wrapper will catch
-            # exceptions and set isError=True via _make_error_result.
             raise McpError(
                 ErrorData(
                     code=INTERNAL_ERROR,
                     message=str(e),
                 )
             ) from e
+        finally:
+            if token is not None:
+                session_context_var.reset(token)
 
     logger.info(
         f"MCP server '{name}' created with {len(route_table.list_routes())} "

--- a/src/toolregistry_server/route_table.py
+++ b/src/toolregistry_server/route_table.py
@@ -48,6 +48,9 @@ class RouteEntry:
     # Validation
     parameters_model: Any | None = None
 
+    # Session-scoped handler factory (optional)
+    handler_factory: Callable[..., Callable[..., Any]] | None = None
+
     # State
     enabled: bool = True
     disable_reason: str | None = None

--- a/src/toolregistry_server/session.py
+++ b/src/toolregistry_server/session.py
@@ -1,0 +1,255 @@
+"""Transport-agnostic session context for tool handlers.
+
+Provides :class:`SessionContext` for per-session state,
+:func:`should_inject_session` for opt-in parameter detection,
+and :class:`SessionManager` for session lifecycle management.
+
+Usage in tool handlers (opt-in via ``_session`` parameter)::
+
+    from toolregistry_server import SessionContext
+
+    def my_tool(x: int, _session: SessionContext) -> str:
+        count = _session.get("call_count", 0) + 1
+        _session.set("call_count", count)
+        return f"Call #{count} in session {_session.session_id}"
+"""
+
+from __future__ import annotations
+
+import contextvars
+import inspect
+import time
+import uuid
+import weakref
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "SessionContext",
+    "SessionManager",
+    "session_context_var",
+    "should_inject_session",
+]
+
+
+# ---------------------------------------------------------------------------
+# Session context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionContext:
+    """Per-session state container injected into tool handlers.
+
+    Args:
+        session_id: Stable identifier for this session.
+        transport: Transport type (``"stdio"``, ``"sse"``,
+            ``"streamable-http"``, ``"openapi"``).
+        created_at: Monotonic timestamp of session creation.
+    """
+
+    session_id: str
+    transport: str
+    created_at: float = field(default_factory=time.monotonic)
+    _data: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Retrieve a value from session data.
+
+        Args:
+            key: The key to look up.
+            default: Value to return if key is absent.
+
+        Returns:
+            The stored value, or *default*.
+        """
+        return self._data.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        """Store a value in session data.
+
+        Args:
+            key: The key to store under.
+            value: The value to store.
+        """
+        self._data[key] = value
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+
+# ---------------------------------------------------------------------------
+# Context variable (secondary access for library code)
+# ---------------------------------------------------------------------------
+
+session_context_var: contextvars.ContextVar[SessionContext] = contextvars.ContextVar(
+    "session_context"
+)
+"""Contextvar holding the current :class:`SessionContext`.
+
+Set by the adapter before handler invocation, reset afterward.
+Useful for library code that cannot use parameter injection.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Opt-in parameter detection
+# ---------------------------------------------------------------------------
+
+
+def should_inject_session(fn: Callable) -> bool:
+    """Check if *fn* has a ``_session`` parameter for session injection.
+
+    The parameter must be named ``_session``.  If a type annotation is
+    present it must be (or contain the string) ``SessionContext``; an
+    untyped ``_session`` parameter also matches.
+
+    Args:
+        fn: The callable to inspect.
+
+    Returns:
+        ``True`` if the function accepts a ``_session`` parameter
+        compatible with :class:`SessionContext`.
+    """
+    try:
+        sig = inspect.signature(fn)
+        if "_session" not in sig.parameters:
+            return False
+        param = sig.parameters["_session"]
+        annotation = param.annotation
+        if annotation is inspect.Parameter.empty:
+            return True
+        if annotation is SessionContext:
+            return True
+        return isinstance(annotation, str) and "SessionContext" in annotation
+    except (ValueError, TypeError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Session manager
+# ---------------------------------------------------------------------------
+
+
+class SessionManager:
+    """Manages session lifecycle and per-session handler caching.
+
+    Transport-agnostic: callers supply a *factory* to
+    :meth:`get_or_create` that builds the :class:`SessionContext`.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[int, SessionContext] = {}
+        self._session_handlers: dict[str, dict[str, Callable]] = {}
+        self._finalizers: dict[int, weakref.finalize] = {}
+
+    # -- session lifecycle ---------------------------------------------------
+
+    def get_or_create(
+        self,
+        session_key: int,
+        factory: Callable[[], SessionContext],
+    ) -> SessionContext:
+        """Return existing session or create one via *factory*.
+
+        Args:
+            session_key: Unique key identifying the session object
+                (typically ``id(session_object)``).
+            factory: Zero-argument callable that creates a new
+                :class:`SessionContext` if one does not exist yet.
+
+        Returns:
+            The :class:`SessionContext` for *session_key*.
+        """
+        ctx = self._sessions.get(session_key)
+        if ctx is not None:
+            return ctx
+        ctx = factory()
+        self._sessions[session_key] = ctx
+        return ctx
+
+    def register_finalizer(self, session_obj: Any, session_key: int) -> None:
+        """Register a weak-reference clean-up for *session_obj*.
+
+        When the MCP SDK's ``ServerSession`` is garbage-collected the
+        associated session data is automatically removed.
+
+        Args:
+            session_obj: The object whose lifetime bounds the session.
+            session_key: The key used in :meth:`get_or_create`.
+        """
+        if session_key not in self._finalizers:
+            self._finalizers[session_key] = weakref.finalize(
+                session_obj,
+                self._remove_session,
+                session_key,
+            )
+
+    def remove_session(self, session_key: int) -> None:
+        """Explicitly remove a session (public API).
+
+        Args:
+            session_key: The key used in :meth:`get_or_create`.
+        """
+        self._remove_session(session_key)
+
+    def _remove_session(self, session_key: int) -> None:
+        """Internal clean-up for a session."""
+        ctx = self._sessions.pop(session_key, None)
+        if ctx is not None:
+            self._session_handlers.pop(ctx.session_id, None)
+        self._finalizers.pop(session_key, None)
+
+    # -- per-session handler caching -----------------------------------------
+
+    def get_session_handler(
+        self,
+        session_id: str,
+        route: Any,
+    ) -> Callable:
+        """Return a per-session handler, creating one if needed.
+
+        If ``route.handler_factory`` is set, the factory is called once
+        per session to produce a handler; subsequent calls return the
+        cached result.  When no factory is set, ``route.handler`` is
+        returned directly.
+
+        Args:
+            session_id: The session identifier.
+            route: A :class:`~toolregistry_server.route_table.RouteEntry`.
+
+        Returns:
+            The handler callable.
+        """
+        if route.handler_factory is None:
+            return route.handler
+
+        handlers = self._session_handlers.setdefault(session_id, {})
+        handler = handlers.get(route.tool_name)
+        if handler is None:
+            handler = route.handler_factory(self._sessions_by_id().get(session_id))
+            handlers[route.tool_name] = handler
+        return handler
+
+    def _sessions_by_id(self) -> dict[str, SessionContext]:
+        """Build a reverse index from session_id → SessionContext."""
+        return {ctx.session_id: ctx for ctx in self._sessions.values()}
+
+    # -- introspection -------------------------------------------------------
+
+    @property
+    def active_session_count(self) -> int:
+        """Number of currently tracked sessions."""
+        return len(self._sessions)
+
+    @staticmethod
+    def new_session_id() -> str:
+        """Generate a new random session identifier."""
+        return uuid.uuid4().hex

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -1,0 +1,285 @@
+"""Integration tests for MCP session context passthrough.
+
+Uses the MCP SDK's in-memory transport to verify that SessionContext
+is correctly created, injected, and reused across tool calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+from toolregistry.tool import Tool
+
+from toolregistry_server import RouteTable
+from toolregistry_server.mcp.adapter import route_table_to_mcp_server
+from toolregistry_server.session import SessionContext
+
+# ---------------------------------------------------------------------------
+# Test tool functions
+# ---------------------------------------------------------------------------
+
+
+def plain_add(a: int, b: int) -> int:
+    """Add two integers without session.
+
+    Args:
+        a: First operand.
+        b: Second operand.
+
+    Returns:
+        Sum of a and b.
+    """
+    return a + b
+
+
+def session_echo(x: int, _session: SessionContext) -> str:
+    """Echo the input along with session info.
+
+    Args:
+        x: A value.
+        _session: Injected session context.
+
+    Returns:
+        String with value and session id.
+    """
+    return f"x={x} session={_session.session_id}"
+
+
+def session_counter(_session: SessionContext) -> str:
+    """Increment and return a per-session counter.
+
+    Args:
+        _session: Injected session context.
+
+    Returns:
+        The current call count for this session.
+    """
+    count = _session.get("count", 0) + 1
+    _session.set("count", count)
+    return f"count={count}"
+
+
+async def async_session_echo(x: int, _session: SessionContext) -> str:
+    """Async version of session_echo.
+
+    Args:
+        x: A value.
+        _session: Injected session context.
+
+    Returns:
+        String with value and session id.
+    """
+    return f"async x={x} session={_session.session_id}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_registry() -> MagicMock:
+    """Create a mock ToolRegistry."""
+    registry = MagicMock()
+    registry._tools = {}
+    registry.is_enabled = MagicMock(return_value=True)
+    registry.get_disable_reason = MagicMock(return_value=None)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# 1. Backward compatibility – tool without _session
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    """Tools without _session should work unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_plain_tool_works(self, mock_registry: MagicMock) -> None:
+        """A tool without _session should execute normally."""
+        tool = Tool.from_function(plain_add)
+        mock_registry._tools = {"plain_add": tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("plain_add", {"a": 3, "b": 4})
+            assert result.isError is False
+            assert result.content[0].text == "7"
+
+
+# ---------------------------------------------------------------------------
+# 2. Session injection
+# ---------------------------------------------------------------------------
+
+
+class TestSessionInjection:
+    """Tools with _session should receive a SessionContext."""
+
+    @pytest.mark.asyncio
+    async def test_session_injected(self, mock_registry: MagicMock) -> None:
+        """A tool with _session: SessionContext should receive session info."""
+        tool = Tool.from_function(session_echo)
+        mock_registry._tools = {"session_echo": tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("session_echo", {"x": 42})
+            assert result.isError is False
+            text = result.content[0].text
+            assert "x=42" in text
+            assert "session=" in text
+            # Session ID should be a non-empty hex string
+            sid = text.split("session=")[1]
+            assert len(sid) == 32  # uuid4().hex
+
+    @pytest.mark.asyncio
+    async def test_async_session_injected(self, mock_registry: MagicMock) -> None:
+        """An async tool with _session should also receive session info."""
+        tool = Tool.from_function(async_session_echo)
+        mock_registry._tools = {"async_session_echo": tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.call_tool("async_session_echo", {"x": 7})
+            assert result.isError is False
+            text = result.content[0].text
+            assert "async x=7" in text
+            assert "session=" in text
+
+
+# ---------------------------------------------------------------------------
+# 3. Session stability within a connection
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStability:
+    """Multiple calls in the same session should share the same SessionContext."""
+
+    @pytest.mark.asyncio
+    async def test_same_session_id_across_calls(self, mock_registry: MagicMock) -> None:
+        """Two calls in the same session should have the same session_id."""
+        tool = Tool.from_function(session_echo)
+        mock_registry._tools = {"session_echo": tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            r1 = await client.call_tool("session_echo", {"x": 1})
+            r2 = await client.call_tool("session_echo", {"x": 2})
+
+            sid1 = r1.content[0].text.split("session=")[1]
+            sid2 = r2.content[0].text.split("session=")[1]
+            assert sid1 == sid2
+
+    @pytest.mark.asyncio
+    async def test_session_state_persists(self, mock_registry: MagicMock) -> None:
+        """Session data should persist across multiple calls."""
+        tool = Tool.from_function(session_counter)
+        mock_registry._tools = {"session_counter": tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            r1 = await client.call_tool("session_counter", {})
+            assert r1.content[0].text == "count=1"
+
+            r2 = await client.call_tool("session_counter", {})
+            assert r2.content[0].text == "count=2"
+
+            r3 = await client.call_tool("session_counter", {})
+            assert r3.content[0].text == "count=3"
+
+
+# ---------------------------------------------------------------------------
+# 4. Different sessions get different contexts
+# ---------------------------------------------------------------------------
+
+
+class TestSessionIsolation:
+    """Different MCP sessions should get independent SessionContexts."""
+
+    @pytest.mark.asyncio
+    async def test_different_sessions_different_ids(
+        self, mock_registry: MagicMock
+    ) -> None:
+        """Two separate sessions should have different session_ids."""
+        tool = Tool.from_function(session_echo)
+        mock_registry._tools = {"session_echo": tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client1:
+            r1 = await client1.call_tool("session_echo", {"x": 1})
+            sid1 = r1.content[0].text.split("session=")[1]
+
+        async with create_connected_server_and_client_session(server) as client2:
+            r2 = await client2.call_tool("session_echo", {"x": 2})
+            sid2 = r2.content[0].text.split("session=")[1]
+
+        assert sid1 != sid2
+
+    @pytest.mark.asyncio
+    async def test_session_state_isolated(self, mock_registry: MagicMock) -> None:
+        """Session state should not leak between sessions."""
+        tool = Tool.from_function(session_counter)
+        mock_registry._tools = {"session_counter": tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        # First session counts to 2
+        async with create_connected_server_and_client_session(server) as client1:
+            await client1.call_tool("session_counter", {})
+            r = await client1.call_tool("session_counter", {})
+            assert r.content[0].text == "count=2"
+
+        # Second session starts fresh at 1
+        async with create_connected_server_and_client_session(server) as client2:
+            r = await client2.call_tool("session_counter", {})
+            assert r.content[0].text == "count=1"
+
+
+# ---------------------------------------------------------------------------
+# 5. Mixed tools (with and without _session)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedTools:
+    """Both plain and session-aware tools should coexist."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_tools_coexist(self, mock_registry: MagicMock) -> None:
+        """Plain and session-aware tools should both work in the same server."""
+        plain_tool = Tool.from_function(plain_add)
+        session_tool = Tool.from_function(session_echo)
+        mock_registry._tools = {
+            "plain_add": plain_tool,
+            "session_echo": session_tool,
+        }
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+
+        async with create_connected_server_and_client_session(server) as client:
+            # Plain tool works
+            r1 = await client.call_tool("plain_add", {"a": 5, "b": 3})
+            assert r1.isError is False
+            assert r1.content[0].text == "8"
+
+            # Session tool works
+            r2 = await client.call_tool("session_echo", {"x": 10})
+            assert r2.isError is False
+            assert "x=10" in r2.content[0].text
+            assert "session=" in r2.content[0].text

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,345 @@
+"""Unit tests for the session module.
+
+Tests SessionContext, should_inject_session, session_context_var,
+and SessionManager independently of any transport adapter.
+"""
+
+from __future__ import annotations
+
+import gc
+from unittest.mock import MagicMock
+
+import pytest
+
+from toolregistry_server.session import (
+    SessionContext,
+    SessionManager,
+    session_context_var,
+    should_inject_session,
+)
+
+# ---------------------------------------------------------------------------
+# SessionContext
+# ---------------------------------------------------------------------------
+
+
+class TestSessionContext:
+    """Tests for SessionContext dataclass."""
+
+    def test_create_with_required_fields(self) -> None:
+        """SessionContext should be created with session_id and transport."""
+        ctx = SessionContext(session_id="abc", transport="stdio")
+        assert ctx.session_id == "abc"
+        assert ctx.transport == "stdio"
+        assert ctx.created_at > 0
+
+    def test_get_set(self) -> None:
+        """get/set should store and retrieve values."""
+        ctx = SessionContext(session_id="s1", transport="sse")
+        assert ctx.get("key") is None
+        assert ctx.get("key", 42) == 42
+
+        ctx.set("key", "hello")
+        assert ctx.get("key") == "hello"
+
+    def test_dict_interface(self) -> None:
+        """__getitem__, __setitem__, __contains__ should work."""
+        ctx = SessionContext(session_id="s2", transport="stdio")
+        ctx["count"] = 10
+        assert ctx["count"] == 10
+        assert "count" in ctx
+        assert "missing" not in ctx
+
+    def test_get_item_missing_key_raises(self) -> None:
+        """__getitem__ should raise KeyError for missing keys."""
+        ctx = SessionContext(session_id="s3", transport="stdio")
+        with pytest.raises(KeyError):
+            _ = ctx["nope"]
+
+    def test_separate_contexts_have_separate_data(self) -> None:
+        """Two SessionContext instances should not share data."""
+        ctx_a = SessionContext(session_id="a", transport="stdio")
+        ctx_b = SessionContext(session_id="b", transport="stdio")
+        ctx_a.set("x", 1)
+        assert ctx_b.get("x") is None
+
+
+# ---------------------------------------------------------------------------
+# should_inject_session
+# ---------------------------------------------------------------------------
+
+
+class TestShouldInjectSession:
+    """Tests for should_inject_session detection."""
+
+    def test_no_session_param(self) -> None:
+        """Function without _session should return False."""
+
+        def f(x: int) -> int:
+            return x
+
+        assert should_inject_session(f) is False
+
+    def test_session_param_typed(self) -> None:
+        """Function with _session: SessionContext should return True."""
+
+        def f(x: int, _session: SessionContext) -> int:
+            return x
+
+        assert should_inject_session(f) is True
+
+    def test_session_param_untyped(self) -> None:
+        """Function with _session (no annotation) should return True."""
+
+        def f(x: int, _session) -> int:  # type: ignore[no-untyped-def]
+            return x
+
+        assert should_inject_session(f) is True
+
+    def test_session_param_string_annotation(self) -> None:
+        """Function with _session: 'SessionContext' (string) should return True."""
+
+        def f(x: int, _session: SessionContext) -> int:
+            return x
+
+        assert should_inject_session(f) is True
+
+    def test_wrong_type_annotation(self) -> None:
+        """Function with _session: int should return False."""
+
+        def f(x: int, _session: int) -> int:
+            return x
+
+        assert should_inject_session(f) is False
+
+    def test_non_callable(self) -> None:
+        """Non-callable should return False without raising."""
+        assert should_inject_session(42) is False  # type: ignore[arg-type]
+
+    def test_lambda(self) -> None:
+        """Lambda without _session should return False."""
+        assert should_inject_session(lambda x: x) is False
+
+
+# ---------------------------------------------------------------------------
+# session_context_var
+# ---------------------------------------------------------------------------
+
+
+class TestSessionContextVar:
+    """Tests for session_context_var contextvar."""
+
+    def test_default_is_unset(self) -> None:
+        """Accessing without set should raise LookupError."""
+        # Reset to ensure clean state
+        token = None
+        try:
+            token = session_context_var.set(
+                SessionContext(session_id="tmp", transport="stdio")
+            )
+            session_context_var.reset(token)
+            token = None
+        except Exception:
+            pass
+
+        with pytest.raises(LookupError):
+            session_context_var.get()
+
+    def test_set_and_reset(self) -> None:
+        """set/reset should manage the contextvar lifecycle."""
+        ctx = SessionContext(session_id="cv1", transport="sse")
+        token = session_context_var.set(ctx)
+        assert session_context_var.get() is ctx
+        session_context_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# SessionManager
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManager:
+    """Tests for SessionManager lifecycle and caching."""
+
+    def test_get_or_create_new(self) -> None:
+        """First call should create a new session via factory."""
+        mgr = SessionManager()
+        ctx = mgr.get_or_create(
+            100, lambda: SessionContext(session_id="s1", transport="stdio")
+        )
+        assert ctx.session_id == "s1"
+
+    def test_get_or_create_existing(self) -> None:
+        """Same key should return the same session (no double-create)."""
+        mgr = SessionManager()
+        factory_calls = 0
+
+        def factory() -> SessionContext:
+            nonlocal factory_calls
+            factory_calls += 1
+            return SessionContext(session_id="s2", transport="sse")
+
+        ctx_a = mgr.get_or_create(200, factory)
+        ctx_b = mgr.get_or_create(200, factory)
+        assert ctx_a is ctx_b
+        assert factory_calls == 1
+
+    def test_different_keys_different_sessions(self) -> None:
+        """Different keys should produce different sessions."""
+        mgr = SessionManager()
+        ctx_a = mgr.get_or_create(
+            1, lambda: SessionContext(session_id="a", transport="stdio")
+        )
+        ctx_b = mgr.get_or_create(
+            2, lambda: SessionContext(session_id="b", transport="stdio")
+        )
+        assert ctx_a is not ctx_b
+        assert ctx_a.session_id != ctx_b.session_id
+
+    def test_remove_session(self) -> None:
+        """remove_session should clean up session data."""
+        mgr = SessionManager()
+        mgr.get_or_create(
+            300, lambda: SessionContext(session_id="s3", transport="stdio")
+        )
+        assert mgr.active_session_count == 1
+
+        mgr.remove_session(300)
+        assert mgr.active_session_count == 0
+
+    def test_remove_nonexistent_session(self) -> None:
+        """Removing a non-existent session should not raise."""
+        mgr = SessionManager()
+        mgr.remove_session(999)  # no error
+
+    def test_new_session_id_unique(self) -> None:
+        """new_session_id should return unique values."""
+        ids = {SessionManager.new_session_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_active_session_count(self) -> None:
+        """active_session_count should track sessions correctly."""
+        mgr = SessionManager()
+        assert mgr.active_session_count == 0
+        mgr.get_or_create(1, lambda: SessionContext(session_id="a", transport="stdio"))
+        assert mgr.active_session_count == 1
+        mgr.get_or_create(2, lambda: SessionContext(session_id="b", transport="stdio"))
+        assert mgr.active_session_count == 2
+        mgr.remove_session(1)
+        assert mgr.active_session_count == 1
+
+
+# ---------------------------------------------------------------------------
+# SessionManager – handler_factory caching
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManagerHandlerFactory:
+    """Tests for per-session handler caching via handler_factory."""
+
+    def test_no_factory_returns_handler(self) -> None:
+        """When handler_factory is None, get_session_handler returns route.handler."""
+        mgr = SessionManager()
+        mgr.get_or_create(1, lambda: SessionContext(session_id="s1", transport="stdio"))
+
+        route = MagicMock()
+        route.handler = lambda: "ok"
+        route.handler_factory = None
+        route.tool_name = "tool1"
+
+        handler = mgr.get_session_handler("s1", route)
+        assert handler is route.handler
+
+    def test_factory_creates_handler(self) -> None:
+        """handler_factory should be called to create a handler for the session."""
+        mgr = SessionManager()
+        ctx = mgr.get_or_create(
+            1, lambda: SessionContext(session_id="s1", transport="stdio")
+        )
+
+        created_handler = MagicMock()
+        factory = MagicMock(return_value=created_handler)
+
+        route = MagicMock()
+        route.handler = MagicMock()
+        route.handler_factory = factory
+        route.tool_name = "tool1"
+
+        handler = mgr.get_session_handler("s1", route)
+        assert handler is created_handler
+        factory.assert_called_once_with(ctx)
+
+    def test_factory_caches_handler(self) -> None:
+        """Subsequent calls for the same session+tool should return cached handler."""
+        mgr = SessionManager()
+        mgr.get_or_create(1, lambda: SessionContext(session_id="s1", transport="stdio"))
+
+        created_handler = MagicMock()
+        factory = MagicMock(return_value=created_handler)
+
+        route = MagicMock()
+        route.handler = MagicMock()
+        route.handler_factory = factory
+        route.tool_name = "tool1"
+
+        h1 = mgr.get_session_handler("s1", route)
+        h2 = mgr.get_session_handler("s1", route)
+        assert h1 is h2
+        assert factory.call_count == 1
+
+    def test_factory_different_sessions_different_handlers(self) -> None:
+        """Different sessions should get different handler instances."""
+        mgr = SessionManager()
+        mgr.get_or_create(1, lambda: SessionContext(session_id="s1", transport="stdio"))
+        mgr.get_or_create(2, lambda: SessionContext(session_id="s2", transport="stdio"))
+
+        route = MagicMock()
+        route.handler = MagicMock()
+        route.handler_factory = MagicMock(side_effect=[MagicMock(), MagicMock()])
+        route.tool_name = "tool1"
+
+        h1 = mgr.get_session_handler("s1", route)
+        h2 = mgr.get_session_handler("s2", route)
+        assert h1 is not h2
+
+    def test_remove_session_clears_cached_handlers(self) -> None:
+        """Removing a session should clear its cached handlers."""
+        mgr = SessionManager()
+        mgr.get_or_create(1, lambda: SessionContext(session_id="s1", transport="stdio"))
+
+        route = MagicMock()
+        route.handler = MagicMock()
+        route.handler_factory = MagicMock(return_value=MagicMock())
+        route.tool_name = "tool1"
+
+        mgr.get_session_handler("s1", route)
+        assert "s1" in mgr._session_handlers
+
+        mgr.remove_session(1)
+        assert "s1" not in mgr._session_handlers
+
+
+# ---------------------------------------------------------------------------
+# SessionManager – weakref finalizer
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManagerFinalizer:
+    """Tests for weakref-based automatic session cleanup."""
+
+    def test_finalizer_cleans_up_on_gc(self) -> None:
+        """When the tracked object is garbage-collected, session is removed."""
+        mgr = SessionManager()
+
+        obj = MagicMock()
+        key = id(obj)
+        mgr.get_or_create(
+            key, lambda: SessionContext(session_id="gc1", transport="stdio")
+        )
+        mgr.register_finalizer(obj, key)
+        assert mgr.active_session_count == 1
+
+        # Drop reference and force GC — triggers finalizer
+        del obj
+        gc.collect()
+        assert mgr.active_session_count == 0


### PR DESCRIPTION
## Summary
- Add `SessionContext` dataclass and `SessionManager` for transport-agnostic session lifecycle management (`session.py`)
- Integrate session context into MCP adapter: auto-detect transport type (stdio/sse/streamable-http), create/reuse sessions per MCP `ServerSession`, inject `_session` parameter into opt-in tool handlers
- Add `handler_factory` field to `RouteEntry` for per-session handler instantiation
- Export `SessionContext` from top-level package

Closes #17

## Design
- **Opt-in injection**: Tools declare `_session: SessionContext` parameter to receive session info (same pattern as toolregistry's `ExecutionContext`)
- **Transport-agnostic**: `SessionContext` lives at top level, designed for both MCP and future OpenAPI adapter support
- **Automatic cleanup**: `weakref.finalize` on MCP `ServerSession` triggers session removal on GC
- **No breaking changes**: Tools without `_session` work exactly as before

## Test plan
- [x] 27 unit tests for SessionContext, should_inject_session, SessionManager (`test_session.py`)
- [x] 8 MCP integration tests using in-memory transport (`test_mcp_session.py`)
  - Backward compatibility (plain tools still work)
  - Session injection (sync and async)
  - Session ID stability across calls
  - Session state persistence (counter pattern)
  - Session isolation between connections
  - Mixed plain + session-aware tools
- [x] Full test suite passes (129/129, excluding pre-existing OpenAPI compat issue with toolregistry 0.6.1)