### PR TITLE
refactor: move zerodep modules into _vendor/ package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS.md — toolregistry-server
+
+> Context file for AI coding assistants. Symlinked as `CLAUDE.md`.
+
+## What this project is
+
+toolregistry-server is a **protocol adapter layer** that exposes tools from
+`toolregistry` via OpenAPI (REST) and MCP (Model Context Protocol) interfaces.
+It sits between the core library and end-user tool collections.
+
+| Package | Role | Depends on |
+|---------|------|------------|
+| `toolregistry` | Core library: `Tool` model, `ToolRegistry`, client integrations | — |
+| `toolregistry-server` (this) | Server infrastructure: `RouteTable`, OpenAPI/MCP adapters, auth, CLI | `toolregistry` |
+| `toolregistry-hub` | Tool implementations + default server configuration | `toolregistry-server` |
+
+Upstream compat is checked weekly via `upstream-compat.yml`; downstream
+(`toolregistry-hub`) is notified on release via `notify-downstream.yml`.
+
+## Architecture
+
+Central bridge: `RouteTable` converts a `ToolRegistry` into protocol-specific
+endpoints. Both adapters read live state from the route table (no drift).
+
+| Module | Purpose |
+|--------|---------|
+| `route_table.py` | Central routing bridge (observer pattern, ETag versioning) |
+| `session.py` | Per-request/session state, `SessionContext`, `SessionManager` |
+| `openapi/adapter.py` | JSON Schema → Pydantic conversion, FastAPI router generation |
+| `openapi/middleware.py` | ETag-based HTTP caching (304 Not Modified) |
+| `mcp/adapter.py` | MCP handler registration, session injection |
+| `mcp/server.py` | Transport runners (stdio, SSE, streamable-http) |
+| `auth/` | Bearer token authentication (FastAPI dependency factory) |
+| `cli/` | CLI entry point with `openapi` / `mcp` subcommands |
+| `_dotenv.py`, `_structlog.py` | Vendored zero-dep modules (from zerodep) |
+
+## Repository layout
+
+```
+src/toolregistry_server/
+├── __init__.py              # Exports: RouteTable, RouteEntry, SessionContext
+├── route_table.py           # Central routing layer
+├── session.py               # Session context + manager
+├── _dotenv.py               # Vendored dotenv parser
+├── _structlog.py            # Vendored structured logging
+├── auth/                    # Bearer token auth
+├── openapi/                 # FastAPI adapter + ETag middleware
+├── mcp/                     # MCP adapter + transport runners
+└── cli/                     # CLI (openapi.py, mcp.py subcommands)
+
+tests/                       # 7 test modules, pytest
+examples/                    # Usage examples
+docs_en/, docs_zh/           # Documentation (git worktrees, orphan branches)
+```
+
+## Setup and commands
+
+```bash
+conda activate toolregistry_server   # or your env name
+pip install -e ".[dev]"
+```
+
+Run `make help` for all targets:
+
+```bash
+make lint          # ruff check + ruff format --check
+make lint-fix      # ruff check --fix + ruff format
+make test          # pytest
+make build         # python -m build
+make push          # twine upload
+```
+
+No pre-commit hooks — quality is enforced by CI workflows and `make lint`.
+
+## Definition of done
+
+1. `make lint` passes (ruff check + format)
+2. `make test` passes across Python 3.10–3.13
+3. New code has tests in `tests/`
+4. Google-style docstrings on public APIs; comments in English
+5. Vendored `_dotenv.py` and `_structlog.py` are never edited directly
+
+## Workflow
+
+- **Branch from master**, open a PR, require CI green before merge.
+- **Merge strategy: rebase** — keep commits atomic and well-messaged.
+- **Conventional commits**: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`
+- Never force-push to `master` unless the user explicitly requests it.
+
+## Documentation
+
+User-facing docs live on **orphan branches** (`docs_en`, `docs_zh`), mounted
+as git worktrees. MkDocs + mkdocs-material, deployed to Zensical.
+
+## Escalation
+
+- Upstream incompatibility → check `upstream-compat.yml` CI, verify `toolregistry` version
+- Vendored files (`_dotenv.py`, `_structlog.py`) → never fix in-place; update in zerodep repo
+- Test failure after 3 attempts → stop, report full output
+- Never: delete files to fix errors, skip tests, modify vendored files directly
+
+## Files to never edit
+
+- `src/toolregistry_server/_dotenv.py` — vendored from zerodep
+- `src/toolregistry_server/_structlog.py` — vendored from zerodep
+- `docs_en/`, `docs_zh/` — separate git branches, edit inside the worktree only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ where = ["src"]
 [tool.ruff]
 line-length = 88
 target-version = "py310"
+exclude = ["src/toolregistry_server/_vendor"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "C4", "SIM"]

--- a/src/toolregistry_server/_vendor/__init__.py
+++ b/src/toolregistry_server/_vendor/__init__.py
@@ -1,0 +1,1 @@
+# Vendored zero-dependency modules from https://github.com/Oaklight/zerodep

--- a/src/toolregistry_server/_vendor/dotenv.py
+++ b/src/toolregistry_server/_vendor/dotenv.py
@@ -1,8 +1,9 @@
 # /// zerodep
-# version = "0.3.0"
+# version = "0.3.1"
 # deps = []
 # tier = "simple"
-# category = "data"
+# category = "config"
+# note = "Install/update via `zerodep add dotenv`"
 # ///
 
 """.env file parser and loader — zero dependencies, stdlib only, Python 3.10+.
@@ -25,9 +26,8 @@ import inspect
 import os
 import re
 import sys
-from collections.abc import Iterator, Mapping
 from pathlib import Path
-from typing import IO
+from typing import IO, Iterator, Mapping
 
 __all__ = [
     "find_dotenv",
@@ -131,6 +131,65 @@ def _interpolate(
     return _INTERPOLATE_RE.sub(_replace, value)
 
 
+def _find_unescaped_quote(text: str) -> int:
+    """Return position of the first unescaped double-quote in *text*, or -1."""
+    pos = 0
+    while pos < len(text):
+        if text[pos] == "\\" and pos + 1 < len(text):
+            pos += 2
+            continue
+        if text[pos] == '"':
+            return pos
+        pos += 1
+    return -1
+
+
+def _collect_multiline_value(
+    lines: list[str], start_idx: int, first_fragment: str
+) -> tuple[str, int]:
+    """Accumulate continuation lines for a multiline double-quoted value.
+
+    Args:
+        lines: All lines of the .env content.
+        start_idx: Index of the first continuation line to inspect.
+        first_fragment: Text after the opening ``"`` on the first line.
+
+    Returns:
+        Tuple of (raw concatenated value, next line index to process).
+    """
+    parts = [first_fragment]
+    i = start_idx
+    while i < len(lines):
+        next_line = lines[i]
+        i += 1
+        close_pos = _find_unescaped_quote(next_line)
+        if close_pos >= 0:
+            parts.append(next_line[:close_pos])
+            break
+        parts.append(next_line)
+    return "".join(parts), i
+
+
+_MULTILINE_OPEN_RE = re.compile(
+    r'\A\s*(?:export\s+)?([A-Za-z_]\w*)\s*=\s*"',
+)
+
+
+def _extract_value_from_match(m: re.Match[str]) -> str | None:
+    """Extract the value from a single-line binding regex match.
+
+    Returns the raw value (unescaped for double-quoted, literal for
+    single-quoted, stripped for unquoted, or None when no ``=`` present).
+    """
+    if m.group("sq") is not None:
+        return m.group("sq")
+    if m.group("dq") is not None:
+        return _unescape_double_quoted(m.group("dq"))
+    if m.group("uq") is not None:
+        return m.group("uq").rstrip()
+    return None
+
+
 def _parse_stream(
     stream: IO[str],
     interpolate: bool = True,
@@ -161,52 +220,13 @@ def _parse_stream(
             continue
 
         # Check for multiline double-quoted values
-        # Detect pattern: KEY="value without closing quote
-        ml_match = re.match(
-            r'\A\s*(?:export\s+)?([A-Za-z_]\w*)\s*=\s*"',
-            line,
-        )
+        ml_match = _MULTILINE_OPEN_RE.match(line)
         if ml_match:
-            # Find the content after the opening quote
             after_eq_quote = line[ml_match.end() :]
-            # Check if the quote is closed on this line
-            # We need to find an unescaped closing quote
-            closed = False
-            temp = after_eq_quote
-            pos = 0
-            while pos < len(temp):
-                if temp[pos] == "\\" and pos + 1 < len(temp):
-                    pos += 2
-                    continue
-                if temp[pos] == '"':
-                    closed = True
-                    break
-                pos += 1
-
-            if not closed:
+            if _find_unescaped_quote(after_eq_quote) < 0:
                 # Multiline: accumulate lines until closing "
                 key = ml_match.group(1)
-                parts = [after_eq_quote]
-                while i < len(lines):
-                    next_line = lines[i]
-                    i += 1
-                    # Check for closing quote
-                    pos = 0
-                    found_close = False
-                    while pos < len(next_line):
-                        if next_line[pos] == "\\" and pos + 1 < len(next_line):
-                            pos += 2
-                            continue
-                        if next_line[pos] == '"':
-                            found_close = True
-                            break
-                        pos += 1
-                    if found_close:
-                        parts.append(next_line[:pos])
-                        break
-                    parts.append(next_line)
-
-                raw_value = "".join(parts)
+                raw_value, i = _collect_multiline_value(lines, i, after_eq_quote)
                 value = _unescape_double_quoted(raw_value)
                 if interpolate:
                     value = _interpolate(value, env, os_environ)
@@ -220,19 +240,7 @@ def _parse_stream(
             continue
 
         key = m.group("key")
-
-        if m.group("sq") is not None:
-            # Single-quoted: literal, no escapes
-            value: str | None = m.group("sq")
-        elif m.group("dq") is not None:
-            # Double-quoted: process escapes
-            value = _unescape_double_quoted(m.group("dq"))
-        elif m.group("uq") is not None:
-            # Unquoted: strip trailing whitespace
-            value = m.group("uq").rstrip()
-        else:
-            # KEY with no =value
-            value = None
+        value: str | None = _extract_value_from_match(m)
 
         if value is not None and interpolate:
             value = _interpolate(value, env, os_environ)
@@ -281,7 +289,7 @@ def find_dotenv(
         current = parent
 
     if raise_error_if_not_found:
-        raise OSError(f"File {filename!r} not found starting from {start}")
+        raise IOError(f"File {filename!r} not found starting from {start}")
     return ""
 
 
@@ -407,6 +415,39 @@ def unset_key(
 # ── Public API ─────────────────────────────────────────────────────────────────
 
 
+def _resolve_dotenv_path(
+    dotenv_path: str | os.PathLike[str] | None,
+    verbose: bool,
+) -> Path | None:
+    """Resolve *dotenv_path* to an existing file, or return None.
+
+    When *verbose* is True and the file does not exist, a warning is printed.
+    """
+    if dotenv_path is None:
+        dotenv_path = find_dotenv(usecwd=True)
+
+    path = Path(dotenv_path)
+    if path.is_file():
+        return path
+
+    if verbose:
+        print(  # noqa: T201
+            f"Python-dotenv could not find configuration file {path}.",
+            file=sys.stderr,
+        )
+    return None
+
+
+def _apply_to_environ(
+    pairs: Iterator[tuple[str, str | None]],
+    override: bool,
+) -> None:
+    """Write parsed (key, value) pairs into ``os.environ``."""
+    for key, value in pairs:
+        if value is not None and (override or key not in os.environ):
+            os.environ[key] = value
+
+
 def dotenv_values(
     dotenv_path: str | os.PathLike[str] | None = None,
     stream: IO[str] | None = None,
@@ -431,16 +472,8 @@ def dotenv_values(
     if stream is not None:
         return dict(_parse_stream(stream, interpolate=interpolate))
 
-    if dotenv_path is None:
-        dotenv_path = find_dotenv(usecwd=True)
-
-    path = Path(dotenv_path)
-    if not path.is_file():
-        if verbose:
-            print(  # noqa: T201
-                f"Python-dotenv could not find configuration file {path}.",
-                file=sys.stderr,
-            )
+    path = _resolve_dotenv_path(dotenv_path, verbose)
+    if path is None:
         return {}
 
     with open(path, encoding=encoding) as f:
@@ -469,25 +502,13 @@ def load_dotenv(
         True if a file was found and loaded.
     """
     if stream is not None:
-        for key, value in _parse_stream(stream, interpolate=interpolate):
-            if value is not None and (override or key not in os.environ):
-                os.environ[key] = value
+        _apply_to_environ(_parse_stream(stream, interpolate=interpolate), override)
         return True
 
-    if dotenv_path is None:
-        dotenv_path = find_dotenv(usecwd=True)
-
-    path = Path(dotenv_path)
-    if not path.is_file():
-        if verbose:
-            print(  # noqa: T201
-                f"Python-dotenv could not find configuration file {path}.",
-                file=sys.stderr,
-            )
+    path = _resolve_dotenv_path(dotenv_path, verbose)
+    if path is None:
         return False
 
     with open(path, encoding=encoding) as f:
-        for key, value in _parse_stream(f, interpolate=interpolate):
-            if value is not None and (override or key not in os.environ):
-                os.environ[key] = value
+        _apply_to_environ(_parse_stream(f, interpolate=interpolate), override)
     return True

--- a/src/toolregistry_server/_vendor/structlog.py
+++ b/src/toolregistry_server/_vendor/structlog.py
@@ -2,7 +2,8 @@
 # version = "0.3.0"
 # deps = []
 # tier = "medium"
-# category = "utility"
+# category = "devtools"
+# note = "Install/update via `zerodep add structlog`"
 # ///
 
 """Zero-dependency structured logging with pretty console output.
@@ -48,8 +49,7 @@ import logging
 import os
 import sys
 import traceback
-from collections.abc import Callable
-from typing import IO, Any
+from typing import IO, Any, Callable
 
 __all__ = [
     # Type aliases
@@ -212,7 +212,9 @@ def _supports_color(stream: Any = None) -> bool:
     s = stream or sys.stderr
     if not hasattr(s, "isatty") or not s.isatty():
         return False
-    return os.environ.get("TERM", "") != "dumb"
+    if os.environ.get("TERM", "") == "dumb":
+        return False
+    return True
 
 
 # ── Logger Factories ─────────────────────────────────────────────────────────

--- a/src/toolregistry_server/cli/__init__.py
+++ b/src/toolregistry_server/cli/__init__.py
@@ -34,7 +34,7 @@ import sys
 from pathlib import Path
 from typing import NoReturn
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 
 logger = get_logger()
 
@@ -56,7 +56,7 @@ def load_env_file(env_path: str | None = None, no_env: bool = False) -> None:
     if no_env:
         return
 
-    from .._dotenv import load_dotenv
+    from .._vendor.dotenv import load_dotenv
 
     path = Path(env_path) if env_path else Path.cwd() / ".env"
 

--- a/src/toolregistry_server/cli/mcp.py
+++ b/src/toolregistry_server/cli/mcp.py
@@ -8,7 +8,7 @@ import asyncio
 import sys
 from typing import TYPE_CHECKING
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 
 logger = get_logger()
 

--- a/src/toolregistry_server/cli/openapi.py
+++ b/src/toolregistry_server/cli/openapi.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 
 logger = get_logger()
 

--- a/src/toolregistry_server/mcp/adapter.py
+++ b/src/toolregistry_server/mcp/adapter.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 from ..session import (
     SessionContext,
     SessionManager,

--- a/src/toolregistry_server/mcp/server.py
+++ b/src/toolregistry_server/mcp/server.py
@@ -24,7 +24,7 @@ Example:
 import asyncio
 from typing import TYPE_CHECKING
 
-from .._structlog import get_logger
+from .._vendor.structlog import get_logger
 
 logger = get_logger()
 


### PR DESCRIPTION
## Summary
- Move `_dotenv.py` and `_structlog.py` into `_vendor/` as `dotenv.py` and `structlog.py`
- Update `dotenv` to 0.3.1 via `zerodep` CLI
- Migrate all internal imports to `_vendor.*` paths

## Test plan
- [x] 179 tests passing locally
- [ ] CI green