### PR TITLE
Add pre-commit hooks and reduce cognitive complexity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.10"
 
-      - name: Install ruff
-        run: pip install ruff ty
+      - name: Install dependencies for ty
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
-      - name: Run ruff check
-        run: ruff check src/ tests/
-
-      - name: Run ruff format check
-        run: ruff format --check src/ tests/
-
-      - name: Type check with ty
-        run: ty check src/
+      - name: Run pre-commit checks
+        uses: pre-commit/action@v3.0.1
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check
+        description: Type check src/ with ty.
+        entry: ty check src/
+        language: system
+        pass_filenames: false
+        require_serial: true
+        types: [python]
+
+  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+    rev: v4.2.0
+    hooks:
+      - id: complexipy
+        pass_filenames: false
+        args: [., -e, src/toolregistry_server/_vendor, -mx, "20"]

--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,28 @@ VERSION := $(shell grep -oE '__version__[[:space:]]*=[[:space:]]*"[^"]+"' src/to
 all: lint test build
 
 # ──────────────────────────────────────────────
-# Linting & Formatting
+# Linting & Type Checking
 # ──────────────────────────────────────────────
 
-# Run ruff linter
+# Run all linting and type checking
 lint:
 	@echo "Running ruff check..."
 	ruff check src/ tests/
 	@echo "Running ruff format check..."
 	ruff format --check src/ tests/
-	@echo "Lint complete."
+	@echo "Running ty check..."
+	ty check src/
+	@echo "Running complexipy..."
+	complexipy . -e src/toolregistry_server/_vendor -mx 20
+	@echo "All checks passed."
 
-# Auto-fix lint issues
-lint-fix:
-	@echo "Auto-fixing lint issues..."
+# Auto-fix and format
+fmt:
+	@echo "Running ruff fix..."
 	ruff check --fix src/ tests/
+	@echo "Running ruff format..."
 	ruff format src/ tests/
-	@echo "Lint fix complete."
+	@echo "Format complete."
 
 # ──────────────────────────────────────────────
 # Testing
@@ -68,8 +73,8 @@ help:
 	@echo "Available targets:"
 	@echo ""
 	@echo "Development:"
-	@echo "  lint           - Run ruff linter and format check"
-	@echo "  lint-fix       - Auto-fix lint and formatting issues"
+	@echo "  lint           - Run ruff, ty, and complexipy checks"
+	@echo "  fmt            - Auto-fix and format with ruff"
 	@echo "  test           - Run tests with pytest"
 	@echo ""
 	@echo "Package targets:"
@@ -82,4 +87,4 @@ help:
 	@echo ""
 	@echo "Detected version: $(VERSION)"
 
-.PHONY: all lint lint-fix test build push clean build push clean help
+.PHONY: all lint fmt test build push clean help

--- a/examples/mcp_server.py
+++ b/examples/mcp_server.py
@@ -10,10 +10,10 @@ by MCP-compatible clients (e.g., Claude Desktop, Claude Code).
 import asyncio
 
 from toolregistry import ToolRegistry
+from tools import add, greet, multiply
+
 from toolregistry_server import RouteTable
 from toolregistry_server.mcp import create_mcp_server, run_stdio
-
-from tools import add, greet, multiply
 
 # 1. Create registry and register tools
 registry = ToolRegistry()

--- a/examples/openapi_server.py
+++ b/examples/openapi_server.py
@@ -9,10 +9,10 @@ Then visit:
 """
 
 from toolregistry import ToolRegistry
+from tools import add, greet, multiply
+
 from toolregistry_server import RouteTable
 from toolregistry_server.openapi import create_openapi_app
-
-from tools import add, greet, multiply
 
 # 1. Create registry and register tools
 registry = ToolRegistry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "httpx>=0.24.0",
     "ruff>=0.1.0",
     "ty>=0.0.21",
+    "complexipy>=4.2.0",
     "build>=1.2.0",
     "twine>=6.1.0",
 ]
@@ -85,9 +86,14 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["src", "tests"]
+exclude = ["src/toolregistry_server/_vendor"]
 
 [tool.ty.rules]
 unresolved-import = "ignore"
+
+[tool.complexipy]
+exclude = ["src/toolregistry_server/_vendor"]
+max-complexity-allowed = 20
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/toolregistry_server/mcp/adapter.py
+++ b/src/toolregistry_server/mcp/adapter.py
@@ -105,6 +105,49 @@ def _serialize_result(result: Any) -> str:
         return str(result)
 
 
+async def _execute_tool(
+    route: Any,
+    arguments: dict,
+    session_ctx: SessionContext | None,
+    session_mgr: "SessionManager",
+) -> Any:
+    """Resolve the handler for a route and execute it with the given arguments.
+
+    Handles session-scoped handler resolution, parameter validation/coercion
+    via the route's Pydantic model, optional session injection, and async/sync
+    dispatch.
+
+    Args:
+        route: The RouteEntry for the tool being invoked.
+        arguments: The input arguments for the tool.
+        session_ctx: The current session context, or None.
+        session_mgr: The SessionManager for handler caching.
+
+    Returns:
+        The raw result from the tool handler.
+    """
+    # Resolve handler (possibly session-scoped)
+    handler = route.handler
+    if route.handler_factory and session_ctx:
+        handler = session_mgr.get_session_handler(session_ctx.session_id, route)
+
+    # Validate and coerce parameters (e.g. string "8" → int 8)
+    if isinstance(route.parameters_model, type) and issubclass(
+        route.parameters_model, BaseModel
+    ):
+        model = route.parameters_model(**arguments)
+        arguments = model.model_dump_one_level()
+
+    # Inject session if handler requests it
+    if session_ctx and should_inject_session(handler):
+        arguments = {**arguments, "_session": session_ctx}
+
+    # Execute the tool handler
+    if route.is_async:
+        return await handler(**arguments)
+    return handler(**arguments)
+
+
 def route_table_to_mcp_server(
     route_table: "RouteTable",
     name: str = "ToolRegistry-Server",
@@ -197,31 +240,8 @@ def route_table_to_mcp_server(
             token = session_context_var.set(session_ctx)
 
         try:
-            # Resolve handler (possibly session-scoped)
-            handler = route.handler
-            if route.handler_factory and session_ctx:
-                handler = session_mgr.get_session_handler(session_ctx.session_id, route)
-
-            # Validate and coerce parameters (e.g. string "8" → int 8)
-            if isinstance(route.parameters_model, type) and issubclass(
-                route.parameters_model, BaseModel
-            ):
-                model = route.parameters_model(**arguments)
-                arguments = model.model_dump_one_level()
-
-            # Inject session if handler requests it
-            if session_ctx and should_inject_session(handler):
-                arguments = {**arguments, "_session": session_ctx}
-
-            # Execute the tool handler
-            if route.is_async:
-                result = await handler(**arguments)
-            else:
-                result = handler(**arguments)
-
-            # Serialize result to text
+            result = await _execute_tool(route, arguments, session_ctx, session_mgr)
             text = _serialize_result(result)
-
             logger.debug(f"call_tool '{name}': success")
             return [TextContent(type="text", text=text)]
 

--- a/src/toolregistry_server/openapi/adapter.py
+++ b/src/toolregistry_server/openapi/adapter.py
@@ -385,6 +385,38 @@ def add_tools_endpoint(app: "FastAPI", route_table: RouteTable) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _filter_disabled_paths(
+    paths: dict[str, Any],
+    disabled_operation_ids: set[str],
+) -> dict[str, Any]:
+    """Remove operations for disabled tools from the OpenAPI paths dict.
+
+    Iterates over all path items and their HTTP methods, dropping any
+    operation whose ``operationId`` appears in *disabled_operation_ids*.
+    Path items that become empty after filtering are omitted entirely.
+
+    Args:
+        paths: The ``paths`` section of an OpenAPI schema.
+        disabled_operation_ids: Set of operation IDs to exclude.
+
+    Returns:
+        A new paths dict with disabled operations removed.
+    """
+    filtered_paths: dict[str, Any] = {}
+    for path, path_item in paths.items():
+        filtered_methods: dict[str, Any] = {}
+        for method, operation in path_item.items():
+            if isinstance(operation, dict):
+                op_id = operation.get("operationId", "")
+                if op_id not in disabled_operation_ids:
+                    filtered_methods[method] = operation
+            else:
+                filtered_methods[method] = operation
+        if filtered_methods:
+            filtered_paths[path] = filtered_methods
+    return filtered_paths
+
+
 def setup_dynamic_openapi(app: "FastAPI", route_table: RouteTable) -> None:
     """Configure dynamic OpenAPI schema generation that filters out disabled tools.
 
@@ -424,19 +456,9 @@ def setup_dynamic_openapi(app: "FastAPI", route_table: RouteTable) -> None:
 
         # Filter out paths whose operations correspond to disabled tools
         if disabled_operation_ids and "paths" in openapi_schema:
-            filtered_paths: dict[str, Any] = {}
-            for path, path_item in openapi_schema["paths"].items():
-                filtered_methods: dict[str, Any] = {}
-                for method, operation in path_item.items():
-                    if isinstance(operation, dict):
-                        op_id = operation.get("operationId", "")
-                        if op_id not in disabled_operation_ids:
-                            filtered_methods[method] = operation
-                    else:
-                        filtered_methods[method] = operation
-                if filtered_methods:
-                    filtered_paths[path] = filtered_methods
-            openapi_schema["paths"] = filtered_paths
+            openapi_schema["paths"] = _filter_disabled_paths(
+                openapi_schema["paths"], disabled_operation_ids
+            )
 
         # Do NOT cache (app.openapi_schema is not set) so the schema
         # is regenerated on every request, reflecting runtime changes.


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with ruff (lint+fix), ruff-format, ty (local hook), and complexipy hooks, mirroring the upstream toolregistry setup
- Update CI lint job to use `pre-commit/action@v3.0.1` instead of separate ruff/ty steps
- Update `Makefile`: add ty and complexipy to `lint` target, rename `lint-fix` → `fmt`
- Add `complexipy` to dev dependencies, configure `[tool.complexipy]` and `[tool.ty.src] exclude` for `_vendor/`
- Extract `_execute_tool()` from `route_table_to_mcp_server` and `_filter_disabled_paths()` from `setup_dynamic_openapi` to bring cognitive complexity under the threshold (20)

## Test plan
- [x] `pre-commit run --all-files` passes all 4 hooks
- [x] `pytest tests/ -v` — 179 tests pass