### PR TITLE
Switch complexipy to local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,11 @@ repos:
         require_serial: true
         types: [python]
 
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
+  - repo: local
     hooks:
       - id: complexipy
+        name: complexipy (complexity check)
+        entry: complexipy src/toolregistry_server tests -e _vendor -mx 20
+        language: system
         pass_filenames: false
-        args: [., -e, src/toolregistry_server/_vendor, -mx, "20"]
+        always_run: true


### PR DESCRIPTION
## Summary
- Replace complexipy pre-commit repo hook with local hook
- The repo hook's `-e` flag does not recursively exclude subdirectories, so vendored subpackages still get scanned
- Local hook with explicit scan paths (`src/toolregistry_server tests`) and `-e _vendor` works correctly

## Test plan
- [x] `pre-commit run complexipy --all-files` passes