### PR TITLE
Centralize route schema normalization

### DIFF
--- a/src/toolregistry_server/mcp/adapter.py
+++ b/src/toolregistry_server/mcp/adapter.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from .._vendor.structlog import get_logger
+from ..route_table import normalize_parameters_schema
 from ..session import (
     SessionContext,
     SessionManager,
@@ -195,7 +196,7 @@ def route_table_to_mcp_server(
                 MCPTool(
                     name=route.tool_name,
                     description=route.description or "",
-                    inputSchema=route.parameters_schema,
+                    inputSchema=normalize_parameters_schema(route.parameters_schema),
                 )
             )
         logger.debug(f"list_tools: returning {len(tools)} enabled tools")

--- a/src/toolregistry_server/openapi/adapter.py
+++ b/src/toolregistry_server/openapi/adapter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, create_model
 
-from ..route_table import RouteEntry, RouteTable
+from ..route_table import RouteEntry, RouteTable, normalize_parameters_schema
 
 if TYPE_CHECKING:
     from fastapi import APIRouter, FastAPI
@@ -97,7 +97,8 @@ def _schema_to_pydantic(name: str, schema: dict[str, Any]) -> type[BaseModel]:
         A dynamically created :class:`pydantic.BaseModel` subclass whose
         fields mirror the schema properties.
     """
-    properties: dict[str, Any] = schema.get("properties", {})
+    schema = normalize_parameters_schema(schema)
+    properties: dict[str, Any] = schema["properties"]
     if not properties:
         # Return an empty model when there are no properties
         return create_model(name)

--- a/src/toolregistry_server/route_table.py
+++ b/src/toolregistry_server/route_table.py
@@ -14,6 +14,18 @@ from toolregistry.events import ChangeEvent, ChangeEventType
 from toolregistry.tool import Tool
 
 
+def normalize_parameters_schema(schema: Any) -> dict[str, Any]:
+    """Return a canonical object schema for tool parameters."""
+    if not isinstance(schema, dict) or schema.get("type") not in (None, "object"):
+        return {"type": "object", "properties": {}}
+
+    normalized = dict(schema)
+    normalized["type"] = "object"
+    if not isinstance(normalized.get("properties"), dict):
+        normalized["properties"] = {}
+    return normalized
+
+
 @dataclass
 class RouteEntry:
     """A single route entry in the central router table.
@@ -153,7 +165,7 @@ class RouteTable:
             method_name=method_name,
             path=f"/tools/{namespace}/{method_name}",
             description=tool.description or "",
-            parameters_schema=tool.parameters,
+            parameters_schema=normalize_parameters_schema(tool.parameters),
             handler=tool.callable,
             is_async=tool.is_async,
             parameters_model=getattr(tool, "parameters_model", None),

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -252,6 +252,29 @@ class TestListTools:
             assert schema["properties"]["b"]["type"] == "integer"
             assert set(schema["required"]) == {"a", "b"}
 
+    @pytest.mark.asyncio
+    async def test_list_tools_normalizes_invalid_input_schema(
+        self, mock_registry: MagicMock
+    ) -> None:
+        """Invalid route schemas are normalized at the MCP boundary."""
+        bad_tool = MagicMock()
+        bad_tool.name = "bad"
+        bad_tool.namespace = "default"
+        bad_tool.method_name = "bad"
+        bad_tool.description = "Bad schema."
+        bad_tool.parameters = {}
+        bad_tool.callable = get_info
+        bad_tool.is_async = False
+        bad_tool.metadata.defer = False
+
+        mock_registry._tools = {"bad": bad_tool}
+
+        route_table = RouteTable(mock_registry)
+        server = route_table_to_mcp_server(route_table)
+        async with create_connected_server_and_client_session(server) as client:
+            result = await client.list_tools()
+            assert result.tools[0].inputSchema == {"type": "object", "properties": {}}
+
 
 # ---------------------------------------------------------------------------
 # 3. enable/disable dynamic reflection (key test)

--- a/tests/test_openapi_adapter.py
+++ b/tests/test_openapi_adapter.py
@@ -138,6 +138,11 @@ class TestSchemaToPydantic:
         instance = model()
         assert instance.count == 10  # ty: ignore[unresolved-attribute]
 
+    def test_non_object_schema_creates_empty_model(self):
+        """Invalid parameter schemas should not break request model generation."""
+        model = _schema_to_pydantic("BadModel", {"type": "string"})
+        assert model.model_fields == {}
+
 
 # ============== Router Generation Tests ==============
 

--- a/tests/test_route_table.py
+++ b/tests/test_route_table.py
@@ -7,6 +7,7 @@ from toolregistry.events import ChangeEvent, ChangeEventType
 from toolregistry.tool import Tool
 
 from toolregistry_server import RouteEntry, RouteTable
+from toolregistry_server.route_table import normalize_parameters_schema
 
 
 class TestRouteEntry:
@@ -57,6 +58,33 @@ class TestRouteEntry:
 
         assert entry.enabled is False
         assert entry.disable_reason == "Under maintenance"
+
+
+class TestNormalizeParametersSchema:
+    """Tests for canonical server parameter schema normalization."""
+
+    def test_normalizes_empty_schema(self) -> None:
+        """Empty schemas become object schemas with properties."""
+        assert normalize_parameters_schema({}) == {"type": "object", "properties": {}}
+
+    def test_normalizes_non_object_schema(self) -> None:
+        """Non-object parameter schemas become empty object schemas."""
+        assert normalize_parameters_schema({"type": "string"}) == {
+            "type": "object",
+            "properties": {},
+        }
+
+    def test_normalizes_missing_properties(self) -> None:
+        """Object schemas with missing properties get an empty properties map."""
+        assert normalize_parameters_schema({"type": "object"}) == {
+            "type": "object",
+            "properties": {},
+        }
+
+    def test_preserves_valid_schema(self) -> None:
+        """Valid object schemas are preserved."""
+        schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        assert normalize_parameters_schema(schema) == schema
 
 
 def _make_mock_registry() -> MagicMock:
@@ -153,6 +181,34 @@ class TestRouteTable:
 
         # Non-existent route
         assert route_table.get_route("nonexistent") is None
+
+    def test_route_table_normalizes_tool_parameters_schema(
+        self, mock_registry: MagicMock, mock_tool: MagicMock
+    ) -> None:
+        """Route entries should store canonical object parameter schemas."""
+        mock_tool.parameters = {"type": "string"}
+        mock_registry._tools = {"greet": mock_tool}
+
+        route_table = RouteTable(mock_registry)
+        route = route_table.get_route("greet")
+
+        assert route is not None
+        assert route.parameters_schema == {"type": "object", "properties": {}}
+
+    def test_route_refresh_normalizes_tool_parameters_schema(
+        self, mock_registry: MagicMock, mock_tool: MagicMock
+    ) -> None:
+        """Route refresh should keep parameter schemas canonical."""
+        mock_registry._tools = {"greet": mock_tool}
+        mock_registry.get_tool = MagicMock(return_value=mock_tool)
+        route_table = RouteTable(mock_registry)
+
+        mock_tool.parameters = {}
+        route_table.refresh("greet")
+        route = route_table.get_route("greet")
+
+        assert route is not None
+        assert route.parameters_schema == {"type": "object", "properties": {}}
 
     def test_list_routes_enabled_only(
         self, mock_registry: MagicMock, mock_tool: MagicMock


### PR DESCRIPTION
## Summary
- normalize parameter schemas at the RouteTable boundary
- reuse canonical route schemas in MCP tools/list and OpenAPI request model generation
- add regressions for empty/non-object schemas across RouteTable, MCP, and OpenAPI adapters

## Test plan
- [x] pre-commit run --all-files
- [x] pytest tests/test_route_table.py tests/test_mcp_adapter.py tests/test_openapi_adapter.py -q