### PR TITLE
feat: ServerIdentity + CLI class for downstream customization

### DIFF
--- a/src/toolregistry_server/__init__.py
+++ b/src/toolregistry_server/__init__.py
@@ -28,6 +28,7 @@ __version__ = "0.3.3"
 
 from .app import App, serve_mcp, serve_openapi
 from .auth import load_tokens
+from .identity import ServerIdentity
 from .registry_builder import (
     PROFILE_DISABLE_TAGS,
     apply_config,
@@ -45,6 +46,7 @@ __all__ = [
     "App",
     "__version__",
     "PROFILE_DISABLE_TAGS",
+    "ServerIdentity",
     "RouteEntry",
     "RouteTable",
     "SessionContext",

--- a/src/toolregistry_server/adapters/mcp/__init__.py
+++ b/src/toolregistry_server/adapters/mcp/__init__.py
@@ -257,10 +257,13 @@ class MCPAdapter(Adapter):
     def create_and_run(cls, route_table: "RouteTable", **kwargs) -> None:
         """Construct and run an MCP server in one step.
 
-        Extracts ``name`` from kwargs for adapter construction; passes
-        ``transport``, ``host``, ``port``, etc. to :meth:`run`.
+        Reads ``identity`` from kwargs for server name default.
+        Explicit ``name`` kwarg takes precedence over identity.
         """
-        name = kwargs.pop("name", "ToolRegistry-Server")
+        from ...identity import ServerIdentity
+
+        identity: ServerIdentity = kwargs.pop("identity", ServerIdentity())
+        name = kwargs.pop("name", identity.name)
         adapter = cls(route_table, name=name)
         adapter.run(**kwargs)
 

--- a/src/toolregistry_server/adapters/openapi/__init__.py
+++ b/src/toolregistry_server/adapters/openapi/__init__.py
@@ -224,21 +224,21 @@ class OpenAPIAdapter(Adapter):
     def create_and_run(cls, route_table: RouteTable, **kwargs) -> None:
         """Construct and run an OpenAPI server in one step.
 
-        Extracts ``tokens_path``, ``title``, ``version``, ``description``
-        from kwargs for adapter construction; passes ``host``, ``port``,
-        ``reload`` to :meth:`run`.
+        Reads ``identity`` from kwargs for title/version/description
+        defaults.  Explicit ``title``/``version``/``description``
+        kwargs take precedence over identity.
         """
         from ...auth import load_tokens
+        from ...identity import ServerIdentity
 
+        identity: ServerIdentity = kwargs.pop("identity", ServerIdentity())
         tokens = load_tokens(kwargs.pop("tokens_path", None))
         adapter = cls(
             route_table,
             tokens=tokens or None,
-            title=kwargs.pop("title", "ToolRegistry Server"),
-            version=kwargs.pop("version", "1.0.0"),
-            description=kwargs.pop(
-                "description", "OpenAPI server for ToolRegistry tools"
-            ),
+            title=kwargs.pop("title", identity.name),
+            version=kwargs.pop("version", identity.version),
+            description=kwargs.pop("description", identity.description),
         )
         adapter.run(**kwargs)
 

--- a/src/toolregistry_server/app.py
+++ b/src/toolregistry_server/app.py
@@ -2,7 +2,7 @@
 
 Provides :class:`App` — the programmatic entry point for running
 servers.  Downstream packages subclass it to customize registry
-construction.
+construction and identity.
 
 Design
 ------
@@ -14,6 +14,10 @@ Design
 2. Wraps it in a ``RouteTable``
 3. Delegates to ``adapter_cls.create_and_run(route_table, **kwargs)``
 
+Identity (product name, version, banner art) is set once on the
+``App`` and automatically flows to adapters — OpenAPI title, MCP
+server name, CLI banner.
+
 ``serve_openapi`` / ``serve_mcp`` are convenience wrappers that
 bind a specific adapter class.  They exist so that end users don't
 need to import adapter classes for the common case::
@@ -21,11 +25,6 @@ need to import adapter classes for the common case::
     # Quick start — no adapter import needed:
     from toolregistry_server import serve_openapi
     serve_openapi(config_path="tools.yaml")
-
-    # Equivalent explicit form:
-    from toolregistry_server.app import App
-    from toolregistry_server.adapters.openapi import OpenAPIAdapter
-    App().serve(OpenAPIAdapter, config_path="tools.yaml")
 
 Adding a new adapter
 ~~~~~~~~~~~~~~~~~~~~
@@ -43,11 +42,15 @@ Override ``prepare_registry`` to customize how the registry is
 built (e.g. built-in tools, hooks, admin panel)::
 
     class HubApp(App):
+        def __init__(self):
+            super().__init__(identity=ServerIdentity(
+                name="ToolRegistry Hub",
+                version=hub_version,
+                banner_art=HUB_BANNER,
+            ))
+
         def prepare_registry(self, **kwargs):
-            registry = build_hub_registry(...)
-            if kwargs.get("admin_port"):
-                registry.enable_admin(port=kwargs["admin_port"])
-            return registry
+            return build_hub_registry(...)
 
     app = HubApp()
     app.serve_mcp(transport="stdio")
@@ -65,15 +68,25 @@ if TYPE_CHECKING:
     from toolregistry import ToolRegistry
 
     from .adapters import Adapter
+    from .identity import ServerIdentity
     from .route_table import RouteTable
 
 
 class App:
     """Server application — builds registry and dispatches to adapters.
 
+    Args:
+        identity: Server identity (name, version, description, banner art).
+            Defaults to ``ServerIdentity()`` (toolregistry-server branding).
+
     Override :meth:`prepare_registry` to customize how the registry
     is constructed (e.g. built-in tools, hooks, metadata overrides).
     """
+
+    def __init__(self, identity: ServerIdentity | None = None) -> None:
+        from .identity import ServerIdentity
+
+        self.identity = identity or ServerIdentity()
 
     def prepare_registry(self, **kwargs) -> ToolRegistry:
         """Build or resolve a ``ToolRegistry``.
@@ -121,29 +134,29 @@ class App:
     def serve(self, adapter_cls: type[Adapter], **kwargs) -> None:
         """Build registry and serve via any adapter.
 
+        Identity is injected into kwargs so adapters can use it
+        (e.g. OpenAPI title, MCP server name).
+
         Args:
             adapter_cls: The adapter class to use (e.g. OpenAPIAdapter).
             **kwargs: Split between :meth:`prepare_registry` and
                 ``adapter_cls.create_and_run``.
         """
+        # Inject identity so adapters can read it
+        kwargs.setdefault("identity", self.identity)
+
         registry = self.prepare_registry(**kwargs)
         route_table = self._make_route_table(registry)
         adapter_cls.create_and_run(route_table, **kwargs)
 
     def serve_openapi(self, **kwargs) -> None:
-        """Build registry and start an OpenAPI server.
-
-        Convenience wrapper for ``serve(OpenAPIAdapter, ...)``.
-        """
+        """Build registry and start an OpenAPI server."""
         from .adapters.openapi import OpenAPIAdapter
 
         self.serve(OpenAPIAdapter, **kwargs)
 
     def serve_mcp(self, **kwargs) -> None:
-        """Build registry and start an MCP server.
-
-        Convenience wrapper for ``serve(MCPAdapter, ...)``.
-        """
+        """Build registry and start an MCP server."""
         from .adapters.mcp import MCPAdapter
 
         self.serve(MCPAdapter, **kwargs)

--- a/src/toolregistry_server/cli.py
+++ b/src/toolregistry_server/cli.py
@@ -1,33 +1,27 @@
-"""
-Command-line interface for ToolRegistry Server.
+"""Command-line interface for ToolRegistry Server.
 
-This module provides the CLI entry point for running ToolRegistry servers
-with support for both OpenAPI and MCP protocols.
+Provides :class:`CLI` — a class-based CLI framework that downstream
+packages subclass to customize parser, banner, and dispatch.
 
 Usage:
-    toolregistry-server openapi [OPTIONS]
-    toolregistry-server mcp [OPTIONS]
-    toolregistry-server --help
+    toolregistry-server openapi --config tools.yaml [OPTIONS]
+    toolregistry-server mcp --config tools.yaml [OPTIONS]
 
-Example:
-    # Start OpenAPI server on port 8000
-    $ toolregistry-server openapi --port 8000
+Subclassing (e.g. Hub)::
 
-    # Start MCP server with stdio transport
-    $ toolregistry-server mcp --transport stdio
+    class HubCLI(CLI):
+        def __init__(self):
+            super().__init__(app=HubApp(identity=hub_identity))
 
-    # Start MCP server with SSE transport
-    $ toolregistry-server mcp --transport sse --port 8000
+        def create_parser(self):
+            parser = super().create_parser()
+            # add hub-specific args to each subparser
+            return parser
 
-    # With configuration file (JSONC or YAML)
-    $ toolregistry-server openapi --config tools.yaml
-
-    # With custom .env file
-    $ toolregistry-server openapi --env /path/to/.env
-
-    # Skip loading .env file
-    $ toolregistry-server openapi --no-env
+    HubCLI().main()
 """
+
+from __future__ import annotations
 
 import argparse
 import sys
@@ -35,12 +29,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from .app import App
 
 from ._vendor.structlog import get_logger
-from .banner import BANNER_ART as DEFAULT_BANNER_ART
 
 logger = get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Standalone utilities (used by CLI and downstream)
+# ---------------------------------------------------------------------------
 
 
 def load_env_file(env_path: str | None = None, no_env: bool = False) -> None:
@@ -61,7 +59,6 @@ def load_env_file(env_path: str | None = None, no_env: bool = False) -> None:
         load_dotenv(path)
         logger.info(f"Loaded environment from {path}")
     elif env_path:
-        # User explicitly specified a path but file doesn't exist
         logger.warning(f"Environment file not found: {path}")
 
 
@@ -70,230 +67,194 @@ def print_banner(
     banner_art: str | None = None,
     extra_lines: list[str] | None = None,
 ) -> None:
-    """Print the ToolRegistry Server banner with centered content and border.
-
-    This function can be used by downstream packages (e.g., toolregistry-hub)
-    to display a customized banner with their own version and art.
+    """Print a bordered ASCII banner.
 
     Args:
-        version: Version string to display. If None, uses toolregistry-server version.
-        banner_art: Custom ASCII art to display. If None, uses default banner.
-        extra_lines: Additional lines to display after the version (e.g., update info).
+        version: Version string to display.
+        banner_art: ASCII art to display. If None, uses default.
+        extra_lines: Additional lines after the version.
     """
     if version is None:
-        from toolregistry_server import __version__
+        from . import __version__
 
         version = __version__
 
     if banner_art is None:
-        banner_art = DEFAULT_BANNER_ART
+        from .banner import BANNER_ART
+
+        banner_art = BANNER_ART
 
     width = 80
     border_char = "·"
-
-    # Split banner art into lines
     art_lines = banner_art.split("\n")
 
-    # Build the banner
     lines = []
-
-    # Top border
     lines.append(border_char * width)
-
-    # Empty line
     lines.append(f": {' ' * (width - 4)} :")
-
-    # Art lines - center each line
     for line in art_lines:
-        centered = line.center(width - 4)
-        lines.append(f": {centered} :")
-
-    # Empty line
+        lines.append(f": {line.center(width - 4)} :")
     lines.append(f": {' ' * (width - 4)} :")
-
-    # Version information
-    version_line = f"Version {version}"
-    centered_version = version_line.center(width - 4)
-    lines.append(f": {centered_version} :")
-
-    # Extra lines (e.g., update available info)
+    lines.append(f": {f'Version {version}'.center(width - 4)} :")
     if extra_lines:
         for extra in extra_lines:
-            centered_extra = extra.center(width - 4)
-            lines.append(f": {centered_extra} :")
-
-    # Empty line
+            lines.append(f": {extra.center(width - 4)} :")
     lines.append(f": {' ' * (width - 4)} :")
-
-    # Bottom border
     lines.append(border_char * width)
-
-    # Print the banner
     print("\n".join(lines))
 
 
-def create_parser() -> argparse.ArgumentParser:
-    """Create the argument parser for the CLI.
+# ---------------------------------------------------------------------------
+# CLI class
+# ---------------------------------------------------------------------------
 
-    Returns:
-        Configured ArgumentParser instance with subcommands.
+
+class CLI:
+    """Class-based CLI framework.
+
+    Subclass and override methods to customize:
+
+    - :meth:`create_parser` — add arguments
+    - :meth:`get_version_string` — version output
+    - :meth:`print_banner` — startup banner
+    - :meth:`dispatch` — command routing
+
+    The :class:`~toolregistry_server.app.App` instance used for dispatch
+    is set via the constructor, enabling identity and registry
+    customization.
     """
-    parser = argparse.ArgumentParser(
-        prog="toolregistry-server",
-        description="Define custom tools and serve them via OpenAPI or MCP interfaces",
-    )
 
-    parser.add_argument(
-        "--version",
-        "-V",
-        action="store_true",
-        help="Show version and exit",
-    )
+    def __init__(self, app: App | None = None) -> None:
+        from .app import App
 
-    parser.add_argument(
-        "--no-banner",
-        action="store_true",
-        help="Disable the startup banner",
-    )
+        self.app = app or App()
 
-    # Create subparsers — each adapter registers its own arguments
-    subparsers = parser.add_subparsers(
-        dest="command",
-        title="commands",
-        description="Available server modes",
-        metavar="{openapi,mcp}",
-    )
+    def create_parser(self) -> argparse.ArgumentParser:
+        """Create the argument parser.
 
-    from .adapters.mcp import MCPAdapter
-    from .adapters.openapi import OpenAPIAdapter
+        Override to add subcommands, change prog name, or add
+        extra arguments.
+        """
+        from .adapters.mcp import MCPAdapter
+        from .adapters.openapi import OpenAPIAdapter
 
-    openapi_parser = subparsers.add_parser(
-        "openapi", help="Start OpenAPI (REST) server"
-    )
-    OpenAPIAdapter.add_cli_arguments(openapi_parser)
-
-    mcp_parser = subparsers.add_parser("mcp", help="Start MCP server")
-    MCPAdapter.add_cli_arguments(mcp_parser)
-
-    return parser
-
-
-def run_cli(
-    parsed: argparse.Namespace,
-    *,
-    version_string: str | None = None,
-    banner_fn: "Callable[[], None] | None" = None,
-    dispatch_fn: "Callable[[argparse.Namespace], None] | None" = None,
-) -> NoReturn | None:
-    """Reusable CLI main loop.
-
-    Handles version flag, no-command help, .env loading, banner,
-    and dispatch.  Downstream packages (e.g. Hub) can override
-    specific steps via keyword arguments.
-
-    Args:
-        parsed: Parsed argparse namespace.
-        version_string: Version string for ``--version`` output.
-            Defaults to ``"toolregistry-server <version>"``.
-        banner_fn: Callable to print the banner.  Defaults to
-            :func:`print_banner`.  Pass ``None`` to skip.
-        dispatch_fn: Callable that receives *parsed* and dispatches
-            to the appropriate serve function.  Defaults to the
-            built-in config-based dispatch.
-    """
-    # Handle version flag
-    if parsed.version:
-        if version_string is None:
-            from toolregistry_server import __version__
-
-            version_string = f"toolregistry-server {__version__}"
-        print(version_string)
-        sys.exit(0)
-
-    # If no command specified, show help
-    if parsed.command is None:
-        # Re-create parser to print help (parsed doesn't carry it)
-        create_parser().print_help()
-        sys.exit(0)
-
-    # Load environment variables from .env file
-    load_env_file(
-        env_path=getattr(parsed, "env", None),
-        no_env=getattr(parsed, "no_env", False),
-    )
-
-    # Print banner
-    if not parsed.no_banner:
-        if banner_fn is not None:
-            banner_fn()
-        else:
-            print_banner()
-
-    # Dispatch
-    try:
-        if dispatch_fn is not None:
-            dispatch_fn(parsed)
-        else:
-            _default_dispatch(parsed)
-    except ImportError as e:
-        logger.error(f"Server dependencies not installed: {e}")
-        logger.info(
-            "Install with: pip install toolregistry-server[openapi] "
-            "or toolregistry-server[mcp]"
+        parser = argparse.ArgumentParser(
+            prog=self.app.identity.prog,
+            description=self.app.identity.description,
         )
-        sys.exit(1)
-    except FileNotFoundError as e:
-        logger.error(str(e))
-        sys.exit(1)
-    except ValueError as e:
-        logger.error(str(e))
-        sys.exit(1)
+        parser.add_argument("--version", "-V", action="store_true", help="Show version")
+        parser.add_argument("--no-banner", action="store_true", help="Disable banner")
 
-    return None
-
-
-def _default_dispatch(parsed: argparse.Namespace) -> None:
-    """Default dispatch for standalone toolregistry-server CLI."""
-    config_path = getattr(parsed, "config", None)
-    if config_path is None:
-        logger.error("No config file specified. Use --config to provide one.")
-        sys.exit(1)
-
-    if parsed.command == "openapi":
-        from toolregistry_server.app import serve_openapi
-
-        serve_openapi(
-            config_path=config_path,
-            profile=getattr(parsed, "profile", None),
-            host=parsed.host,
-            port=parsed.port,
-            tokens_path=getattr(parsed, "tokens", None),
-            reload=getattr(parsed, "reload", False),
+        subparsers = parser.add_subparsers(
+            dest="command",
+            metavar="{openapi,mcp}",
         )
-    elif parsed.command == "mcp":
-        from toolregistry_server.app import serve_mcp
 
-        serve_mcp(
-            config_path=config_path,
-            profile=getattr(parsed, "profile", None),
-            host=parsed.host,
-            port=parsed.port,
-            transport=parsed.transport,
+        openapi_parser = subparsers.add_parser("openapi", help="Start OpenAPI server")
+        OpenAPIAdapter.add_cli_arguments(openapi_parser)
+
+        mcp_parser = subparsers.add_parser("mcp", help="Start MCP server")
+        MCPAdapter.add_cli_arguments(mcp_parser)
+
+        return parser
+
+    def get_version_string(self) -> str:
+        """Return version string for ``--version`` output."""
+        identity = self.app.identity
+        return f"{identity.name} {identity.version}"
+
+    def print_banner(self) -> None:
+        """Print the startup banner using identity."""
+        identity = self.app.identity
+        print_banner(
+            version=identity.version,
+            banner_art=identity.banner_art,
         )
+
+    def dispatch(self, parsed: argparse.Namespace) -> None:
+        """Route parsed args to app.serve_*.
+
+        Override to add custom commands or pre-processing.
+        """
+        config_path = getattr(parsed, "config", None)
+        if config_path is None:
+            logger.error("No config file specified. Use --config to provide one.")
+            sys.exit(1)
+
+        if parsed.command == "openapi":
+            self.app.serve_openapi(
+                config_path=config_path,
+                profile=getattr(parsed, "profile", None),
+                host=parsed.host,
+                port=parsed.port,
+                tokens_path=getattr(parsed, "tokens", None),
+                reload=getattr(parsed, "reload", False),
+            )
+        elif parsed.command == "mcp":
+            self.app.serve_mcp(
+                config_path=config_path,
+                profile=getattr(parsed, "profile", None),
+                host=parsed.host,
+                port=parsed.port,
+                transport=parsed.transport,
+            )
+
+    def main(self, args: list[str] | None = None) -> NoReturn | None:
+        """Run the CLI."""
+        parser = self.create_parser()
+        parsed = parser.parse_args(args)
+
+        # --version
+        if parsed.version:
+            print(self.get_version_string())
+            sys.exit(0)
+
+        # No command → help
+        if parsed.command is None:
+            parser.print_help()
+            sys.exit(0)
+
+        # Load .env
+        load_env_file(
+            env_path=getattr(parsed, "env", None),
+            no_env=getattr(parsed, "no_env", False),
+        )
+
+        # Banner
+        if not parsed.no_banner:
+            self.print_banner()
+
+        # Dispatch with error handling
+        try:
+            self.dispatch(parsed)
+        except ImportError as e:
+            logger.error(f"Server dependencies not installed: {e}")
+            sys.exit(1)
+        except FileNotFoundError as e:
+            logger.error(str(e))
+            sys.exit(1)
+        except ValueError as e:
+            logger.error(str(e))
+            sys.exit(1)
+
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Module-level entry point
+# ---------------------------------------------------------------------------
 
 
 def main(args: list[str] | None = None) -> NoReturn | None:
-    """Main entry point for the standalone toolregistry-server CLI."""
-    parser = create_parser()
-    parsed = parser.parse_args(args)
-    return run_cli(parsed)
+    """Entry point for ``toolregistry-server`` CLI."""
+    return CLI().main(args)
 
+
+# Backward compat — kept for downstream that imports these
+# (Hub currently uses print_banner and load_env_file directly)
 
 __all__ = [
-    "DEFAULT_BANNER_ART",
-    "create_parser",
+    "CLI",
     "load_env_file",
     "main",
     "print_banner",
-    "run_cli",
 ]

--- a/src/toolregistry_server/identity.py
+++ b/src/toolregistry_server/identity.py
@@ -1,0 +1,55 @@
+"""Server identity configuration.
+
+A :class:`ServerIdentity` instance carries branding information that
+flows through all layers — CLI banner, OpenAPI metadata, MCP server
+name, and admin panel title.
+
+Default values match the standalone ``toolregistry-server`` package.
+Downstream projects (e.g. toolregistry-hub) create their own instance::
+
+    identity = ServerIdentity(
+        name="ToolRegistry Hub",
+        version="1.2.0",
+        banner_art=HUB_BANNER_ART,
+    )
+    app = HubApp(identity=identity)
+    app.serve_mcp(transport="stdio")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ServerIdentity:
+    """Branding and metadata for a server instance.
+
+    Attributes:
+        name: Human-readable product name.  Used as the OpenAPI title,
+            MCP server name, and admin panel heading.
+        version: Version string displayed in banner and OpenAPI schema.
+            Defaults to the ``toolregistry-server`` package version.
+        description: Short description for the OpenAPI schema.
+        banner_art: ASCII art for the CLI banner.  ``None`` means use
+            the default ``toolregistry-server`` banner.
+    """
+
+    name: str = "ToolRegistry Server"
+    version: str = ""
+    description: str = "Tool server powered by toolregistry"
+    banner_art: str | None = None
+    prog: str = ""
+    """CLI program name (e.g. ``toolregistry-server``).
+
+    Defaults to ``name`` lowercased with spaces replaced by hyphens.
+    Set explicitly for names with punctuation or non-ASCII characters.
+    """
+
+    def __post_init__(self) -> None:
+        if not self.version:
+            from . import __version__
+
+            object.__setattr__(self, "version", __version__)
+        if not self.prog:
+            object.__setattr__(self, "prog", self.name.lower().replace(" ", "-"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from toolregistry_server.cli import create_parser, main
+from toolregistry_server.cli import CLI, main
 
 
 class TestCreateParser:
@@ -15,31 +15,31 @@ class TestCreateParser:
 
     def test_parser_creation(self):
         """Test that parser is created successfully."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         assert isinstance(parser, argparse.ArgumentParser)
         assert parser.prog == "toolregistry-server"
 
     def test_version_flag(self):
         """Test --version flag is recognized."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(["--version"])
         assert args.version is True
 
     def test_version_short_flag(self):
         """Test -V flag is recognized."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(["-V"])
         assert args.version is True
 
     def test_no_command(self):
         """Test parsing with no command."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args([])
         assert args.command is None
 
     def test_openapi_command(self):
         """Test openapi subcommand parsing."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(["openapi"])
         assert args.command == "openapi"
         assert args.host == "0.0.0.0"
@@ -50,7 +50,7 @@ class TestCreateParser:
 
     def test_openapi_with_options(self):
         """Test openapi subcommand with all options."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(
             [
                 "openapi",
@@ -74,7 +74,7 @@ class TestCreateParser:
 
     def test_mcp_command(self):
         """Test mcp subcommand parsing."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(["mcp"])
         assert args.command == "mcp"
         assert args.transport == "stdio"
@@ -84,7 +84,7 @@ class TestCreateParser:
 
     def test_mcp_with_options(self):
         """Test mcp subcommand with all options."""
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(
             [
                 "mcp",
@@ -106,7 +106,7 @@ class TestCreateParser:
 
     def test_mcp_transport_choices(self):
         """Test mcp transport choices."""
-        parser = create_parser()
+        parser = CLI().create_parser()
 
         # Valid choices
         for transport in ["stdio", "sse", "streamable-http"]:
@@ -128,7 +128,7 @@ class TestMain:
         assert exc_info.value.code == 0
 
         captured = capsys.readouterr()
-        assert "toolregistry-server" in captured.out
+        assert "ToolRegistry Server" in captured.out
 
     def test_no_command_shows_help(self, capsys):
         """Test that no command shows help."""
@@ -136,7 +136,9 @@ class TestMain:
             main([])
         assert exc_info.value.code == 0
 
-    @patch("toolregistry_server.app.serve_openapi")
+    @patch.object(
+        __import__("toolregistry_server.app", fromlist=["App"]).App, "serve_openapi"
+    )
     def test_openapi_command_dispatch(self, mock_serve):
         """Test openapi command dispatches correctly."""
         main(["openapi", "--config", "tools.yaml", "--port", "9000"])
@@ -149,7 +151,9 @@ class TestMain:
             reload=False,
         )
 
-    @patch("toolregistry_server.app.serve_openapi")
+    @patch.object(
+        __import__("toolregistry_server.app", fromlist=["App"]).App, "serve_openapi"
+    )
     def test_openapi_command_dispatch_with_profile(self, mock_serve):
         """Test openapi command passes profile correctly."""
         main(
@@ -172,7 +176,7 @@ class TestMain:
             reload=False,
         )
 
-    @patch("toolregistry_server.app.serve_mcp")
+    @patch("toolregistry_server.app.App.serve_mcp")
     def test_mcp_command_dispatch(self, mock_serve):
         """Test mcp command dispatches correctly."""
         main(["mcp", "--config", "tools.yaml", "--transport", "sse", "--port", "9000"])
@@ -184,7 +188,7 @@ class TestMain:
             transport="sse",
         )
 
-    @patch("toolregistry_server.app.serve_mcp")
+    @patch("toolregistry_server.app.App.serve_mcp")
     def test_mcp_command_dispatch_with_profile(self, mock_serve):
         """Test mcp command passes profile correctly."""
         main(["mcp", "--config", "tools.yaml", "--profile", "remote"])
@@ -671,25 +675,25 @@ class TestCreateRegistryFromConfigWithHooks:
 
     def test_parser_has_profile_openapi(self):
         """Parser exposes --profile for openapi subcommand."""
-        from toolregistry_server.cli import create_parser
+        from toolregistry_server.cli import CLI
 
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(["openapi", "--profile", "remote"])
         assert args.profile == "remote"
 
     def test_parser_has_profile_mcp(self):
         """Parser exposes --profile for mcp subcommand."""
-        from toolregistry_server.cli import create_parser
+        from toolregistry_server.cli import CLI
 
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(["mcp", "--profile", "local"])
         assert args.profile == "local"
 
     def test_parser_profile_default_none(self):
         """--profile defaults to None when not provided."""
-        from toolregistry_server.cli import create_parser
+        from toolregistry_server.cli import CLI
 
-        parser = create_parser()
+        parser = CLI().create_parser()
         args = parser.parse_args(["openapi"])
         assert args.profile is None
 


### PR DESCRIPTION
## Summary

Two features that enable downstream projects (Hub, uxarray) to fully
customize their server identity and CLI without code duplication.

### ServerIdentity

`ServerIdentity` dataclass carries branding: `name`, `version`,
`description`, `banner_art`. Set once on `App`, flows everywhere:

```python
identity = ServerIdentity(
    name="ToolRegistry Hub",
    version="1.2.0",
    banner_art=HUB_BANNER,
)
app = HubApp(identity=identity)
```

- OpenAPI adapter reads `identity.name` → FastAPI title
- MCP adapter reads `identity.name` → MCP server name
- CLI banner reads `identity.banner_art` + `identity.version`
- `--version` outputs `identity.name identity.version`

### CLI class

`CLI` class replaces the function-based `run_cli()`. Override points:

- `create_parser()` — add subcommands/args
- `get_version_string()` — customize version output
- `print_banner()` — customize banner
- `dispatch()` — route to app.serve_*

```python
class HubCLI(CLI):
    def __init__(self):
        super().__init__(app=HubApp(identity=hub_identity))
    def create_parser(self):
        parser = super().create_parser()
        # add --admin-port, etc.
        return parser

HubCLI().main()
```

Closes #40

## Test plan

- [x] 211 tests pass
- [x] Pre-commit clean (ruff, ty, complexipy)