### PR TITLE
refactor: add configure_subparsers hook and lazy-init default App

### DIFF
--- a/src/toolregistry_server/app.py
+++ b/src/toolregistry_server/app.py
@@ -163,10 +163,25 @@ class App:
 
 
 # ---------------------------------------------------------------------------
-# Module-level convenience functions (default App instance)
+# Module-level convenience functions (lazy-init default App)
 # ---------------------------------------------------------------------------
 
-_default_app = App()
+_default_app: App | None = None
 
-serve_openapi = _default_app.serve_openapi
-serve_mcp = _default_app.serve_mcp
+
+def _get_default_app() -> App:
+    """Return the shared default App, creating it on first use."""
+    global _default_app
+    if _default_app is None:
+        _default_app = App()
+    return _default_app
+
+
+def serve_openapi(**kwargs) -> None:
+    """Build registry and start an OpenAPI server."""
+    _get_default_app().serve_openapi(**kwargs)
+
+
+def serve_mcp(**kwargs) -> None:
+    """Build registry and start an MCP server."""
+    _get_default_app().serve_mcp(**kwargs)

--- a/src/toolregistry_server/cli.py
+++ b/src/toolregistry_server/cli.py
@@ -13,10 +13,9 @@ Subclassing (e.g. Hub)::
         def __init__(self):
             super().__init__(app=HubApp(identity=hub_identity))
 
-        def create_parser(self):
-            parser = super().create_parser()
-            # add hub-specific args to each subparser
-            return parser
+        def configure_subparsers(self, subparsers):
+            for sp in subparsers.values():
+                sp.add_argument("--admin-port", type=int)
 
     HubCLI().main()
 """
@@ -113,7 +112,7 @@ class CLI:
 
     Subclass and override methods to customize:
 
-    - :meth:`create_parser` — add arguments
+    - :meth:`configure_subparsers` — add arguments to subparsers
     - :meth:`get_version_string` — version output
     - :meth:`print_banner` — startup banner
     - :meth:`dispatch` — command routing
@@ -131,8 +130,10 @@ class CLI:
     def create_parser(self) -> argparse.ArgumentParser:
         """Create the argument parser.
 
-        Override to add subcommands, change prog name, or add
-        extra arguments.
+        Builds the top-level parser and ``openapi`` / ``mcp``
+        subparsers, then calls :meth:`configure_subparsers` so
+        subclasses can add extra arguments without touching
+        argparse internals.
         """
         from .adapters.mcp import MCPAdapter
         from .adapters.openapi import OpenAPIAdapter
@@ -144,18 +145,37 @@ class CLI:
         parser.add_argument("--version", "-V", action="store_true", help="Show version")
         parser.add_argument("--no-banner", action="store_true", help="Disable banner")
 
-        subparsers = parser.add_subparsers(
+        sub = parser.add_subparsers(
             dest="command",
             metavar="{openapi,mcp}",
         )
 
-        openapi_parser = subparsers.add_parser("openapi", help="Start OpenAPI server")
+        openapi_parser = sub.add_parser("openapi", help="Start OpenAPI server")
         OpenAPIAdapter.add_cli_arguments(openapi_parser)
 
-        mcp_parser = subparsers.add_parser("mcp", help="Start MCP server")
+        mcp_parser = sub.add_parser("mcp", help="Start MCP server")
         MCPAdapter.add_cli_arguments(mcp_parser)
 
+        self.configure_subparsers({"openapi": openapi_parser, "mcp": mcp_parser})
+
         return parser
+
+    def configure_subparsers(
+        self, subparsers: dict[str, argparse.ArgumentParser]
+    ) -> None:
+        """Hook for subclasses to add arguments to subparsers.
+
+        Called by :meth:`create_parser` after all subparsers are
+        created.  Override to add extra CLI flags without accessing
+        argparse private API::
+
+            def configure_subparsers(self, subparsers):
+                for sp in subparsers.values():
+                    sp.add_argument("--admin-port", type=int)
+
+        Args:
+            subparsers: Mapping of command name to its sub-parser.
+        """
 
     def get_version_string(self) -> str:
         """Return version string for ``--version`` output."""

--- a/src/toolregistry_server/cli.py
+++ b/src/toolregistry_server/cli.py
@@ -176,6 +176,7 @@ class CLI:
         Args:
             subparsers: Mapping of command name to its sub-parser.
         """
+        pass
 
     def get_version_string(self) -> str:
         """Return version string for ``--version`` output."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,41 @@ class TestCreateParser:
             parser.parse_args(["mcp", "--transport", "invalid"])
 
 
+class TestConfigureSubparsers:
+    """Tests for configure_subparsers hook."""
+
+    def test_hook_receives_subparsers(self):
+        """configure_subparsers is called with the subparser dict."""
+        received = {}
+
+        class CustomCLI(CLI):
+            def configure_subparsers(self, subparsers):
+                received.update(subparsers)
+
+        CustomCLI().create_parser()
+        assert "openapi" in received
+        assert "mcp" in received
+        assert all(isinstance(sp, argparse.ArgumentParser) for sp in received.values())
+
+    def test_hook_adds_arguments(self):
+        """Arguments added in configure_subparsers are available."""
+
+        class CustomCLI(CLI):
+            def configure_subparsers(self, subparsers):
+                for sp in subparsers.values():
+                    sp.add_argument("--custom-flag", type=int, default=42)
+
+        parser = CustomCLI().create_parser()
+        args = parser.parse_args(["openapi", "--custom-flag", "99"])
+        assert args.custom_flag == 99
+
+    def test_base_hook_is_noop(self):
+        """Base CLI.configure_subparsers does nothing (no error)."""
+        parser = CLI().create_parser()
+        args = parser.parse_args(["openapi"])
+        assert args.command == "openapi"
+
+
 class TestMain:
     """Tests for main function."""
 


### PR DESCRIPTION
## Summary

- `CLI.create_parser()` now calls `configure_subparsers(subparsers)` after building subparsers, giving downstream a clean hook to add arguments without accessing argparse private API (`_subparsers`/`_actions`/`_SubParsersAction`)
- Module-level `serve_openapi`/`serve_mcp` now lazy-init the default `App` on first call instead of at import time, avoiding a redundant instance when only the CLI path is used

## Test plan

- [x] 211 tests pass
- [x] ruff clean