### PR TITLE
fix: await coroutine from _FunctionToolWrapper and unwrap for session injection

### DIFF
--- a/src/toolregistry_server/adapters/mcp/adapter.py
+++ b/src/toolregistry_server/adapters/mcp/adapter.py
@@ -5,6 +5,7 @@ ensuring tool enable/disable state is always read directly from the route table
 at request time (no drift).
 """
 
+import inspect
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -143,10 +144,16 @@ async def _execute_tool(
     if session_ctx and should_inject_session(handler):
         arguments = {**arguments, "_session": session_ctx}
 
-    # Execute the tool handler
+    # Execute the tool handler.
+    # Always check for awaitable results: _FunctionToolWrapper.__call__
+    # returns a coroutine when a running event loop is detected, even for
+    # sync functions (is_async=False).
     if route.is_async:
         return await handler(**arguments)
-    return handler(**arguments)
+    result = handler(**arguments)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 def route_table_to_mcp_server(

--- a/src/toolregistry_server/session.py
+++ b/src/toolregistry_server/session.py
@@ -111,6 +111,11 @@ def should_inject_session(fn: Callable) -> bool:
     present it must be (or contain the string) ``SessionContext``; an
     untyped ``_session`` parameter also matches.
 
+    When *fn* is a ``BaseToolWrapper`` (e.g. ``_FunctionToolWrapper``),
+    the check is performed against the underlying function (``fn.fn``)
+    so that the wrapper's generic ``(*args, **kwargs)`` signature does
+    not hide the real parameter list.
+
     Args:
         fn: The callable to inspect.
 
@@ -118,8 +123,10 @@ def should_inject_session(fn: Callable) -> bool:
         ``True`` if the function accepts a ``_session`` parameter
         compatible with :class:`SessionContext`.
     """
+    # Unwrap BaseToolWrapper to inspect the real function signature.
+    target: Callable = getattr(fn, "fn", fn)
     try:
-        sig = inspect.signature(fn)
+        sig = inspect.signature(target)
         if "_session" not in sig.parameters:
             return False
         param = sig.parameters["_session"]


### PR DESCRIPTION
## Summary

- **Coroutine bug**: `_FunctionToolWrapper.__call__` returns a coroutine when called inside an async event loop (i.e. always in MCP server), even for sync tools (`is_async=False`). The MCP adapter's `_execute_tool()` did not `await` these, so raw coroutine objects were serialized as tool results (e.g. `<coroutine object _FunctionToolWrapper.call_async at 0x...>`).
- **Session injection bug**: `should_inject_session()` called `inspect.signature()` on the `_FunctionToolWrapper` instance, getting `(*args, **kwargs)` instead of the real function signature, so `_session` parameters were never detected and session context was never injected.

## Changes

- `adapters/mcp/adapter.py`: check `inspect.isawaitable()` on sync handler results and `await` if needed
- `session.py`: unwrap `_FunctionToolWrapper` via `getattr(fn, "fn", fn)` before signature inspection

## Test plan

- [x] All 216 tests pass (previously 8 session tests were failing)
- [x] Manual verification: `bash-execute` and `file_ops-read` return actual results instead of coroutine objects when invoked via MCP