### PR TITLE
refactor: add mcp v1/v2 compat layer for server-side adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = ["toolregistry>=0.14.0,<1.0.0"]
 
 [project.optional-dependencies]
 openapi = ["fastapi>=0.119.0", "uvicorn[standard]>=0.24.0"]
-mcp = ["mcp>=1.17.0"]
+mcp = ["mcp>=1.17.0,<2"]
 all = ["toolregistry-server[openapi]", "toolregistry-server[mcp]"]
 dev = [
     "pytest>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = ["toolregistry>=0.14.0,<1.0.0"]
 
 [project.optional-dependencies]
 openapi = ["fastapi>=0.119.0", "uvicorn[standard]>=0.24.0"]
-mcp = ["mcp>=1.8.0"]
+mcp = ["mcp>=1.17.0"]
 all = ["toolregistry-server[openapi]", "toolregistry-server[mcp]"]
 dev = [
     "pytest>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = ["toolregistry>=0.14.0,<1.0.0"]
 
 [project.optional-dependencies]
 openapi = ["fastapi>=0.119.0", "uvicorn[standard]>=0.24.0"]
-mcp = ["mcp>=1.17.0,<2"]
+mcp = ["mcp>=1.17.0,<3"]
 all = ["toolregistry-server[openapi]", "toolregistry-server[mcp]"]
 dev = [
     "pytest>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,10 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["src", "tests"]
-exclude = ["src/toolregistry_server/_vendor"]
+exclude = [
+    "src/toolregistry_server/_vendor",
+    "src/toolregistry_server/adapters/mcp/_compat.py",
+]
 
 [tool.ty.rules]
 unresolved-import = "ignore"

--- a/src/toolregistry_server/adapters/mcp/_compat.py
+++ b/src/toolregistry_server/adapters/mcp/_compat.py
@@ -70,15 +70,22 @@ _v2_request_ctx: contextvars.ContextVar[Any] = contextvars.ContextVar(
 )
 
 
-def get_mcp_session_info() -> tuple[Any, Any | None] | None:
-    """Return ``(mcp_session, starlette_request | None)`` for the current request.
+_STDIO_SESSION_KEY = "stdio-singleton"
 
-    Works transparently with both v1 (reads ``request_ctx`` contextvar)
-    and v2 (reads the ctx we stashed from the handler parameter).
+
+def get_mcp_session_info() -> tuple[Any, Any | None, Any] | None:
+    """Return ``(mcp_session, request, session_key)`` for the current request.
+
+    Works transparently with both v1 and v2.  The *session_key* is a
+    hashable value suitable for deduplicating session contexts:
+
+    - v1: ``id(session)`` (the same ``ServerSession`` object is reused)
+    - v2 with HTTP request: ``mcp-session-id`` header value
+    - v2 without request (stdio/direct): a module-level constant
+      (single logical session)
 
     Returns:
-        A tuple of (session, request) or ``None`` when called outside
-        an MCP request context.
+        A 3-tuple or ``None`` when called outside an MCP request context.
     """
     if MCP_VERSION >= 2:
         ctx = _v2_request_ctx.get(None)
@@ -86,7 +93,12 @@ def get_mcp_session_info() -> tuple[Any, Any | None] | None:
             return None
         session = ctx.session
         request = getattr(ctx, "request", None)
-        return session, request
+        if request is not None:
+            headers = getattr(request, "headers", {})
+            session_key = headers.get("mcp-session-id", id(session))
+        else:
+            session_key = _STDIO_SESSION_KEY
+        return session, request, session_key
     else:
         try:
             from mcp.server.lowlevel.server import request_ctx
@@ -97,7 +109,7 @@ def get_mcp_session_info() -> tuple[Any, Any | None] | None:
             return None
         session = mcp_ctx.session
         request = getattr(mcp_ctx, "request", None)
-        return session, request
+        return session, request, id(session)
 
 
 # ---------------------------------------------------------------------------
@@ -179,9 +191,11 @@ def _create_server_v2(
             arguments = params.arguments or {}
             content = await call_tool_handler(tool_name, arguments)
             return CallToolResult(content=content, is_error=False)  # type: ignore[call-arg]
-        except McpErrorClass:
-            raise
         except Exception as e:
+            # In v2, MCPError raised from on_call_tool becomes a JSON-RPC
+            # protocol error (client raises instead of getting is_error=True).
+            # Catch everything and return as is_error=True to preserve v1
+            # behavior where errors are LLM-visible tool results.
             return CallToolResult(  # type: ignore[call-arg]
                 content=[TextContent(type="text", text=str(e))],
                 is_error=True,
@@ -199,6 +213,16 @@ def _create_server_v2(
 # ---------------------------------------------------------------------------
 # Field accessor
 # ---------------------------------------------------------------------------
+
+
+def make_mcp_tool(name: str, description: str, schema: dict) -> Any:
+    """Create an MCP Tool with the correct field name for the version."""
+    from mcp.types import Tool
+
+    if MCP_VERSION >= 2:
+        return Tool(name=name, description=description, input_schema=schema)
+    else:
+        return Tool(name=name, description=description, inputSchema=schema)
 
 
 _MISSING = object()

--- a/src/toolregistry_server/adapters/mcp/_compat.py
+++ b/src/toolregistry_server/adapters/mcp/_compat.py
@@ -1,0 +1,249 @@
+"""MCP SDK v1/v2 compatibility layer.
+
+Abstracts the breaking changes between mcp v1.x and v2.x so that the
+adapter and test code works with either version.  When we eventually
+implement our own MCP SDK, only this file needs a new backend.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Callable, Coroutine
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.server.lowlevel import Server
+    from mcp.types import TextContent
+    from mcp.types import Tool as MCPTool
+
+# ---------------------------------------------------------------------------
+# Version detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_mcp_version() -> int:
+    try:
+        from mcp.shared.exceptions import MCPError  # noqa: F811
+
+        del MCPError
+        return 2
+    except ImportError:
+        return 1
+
+
+MCP_VERSION: int = _detect_mcp_version()
+
+# ---------------------------------------------------------------------------
+# Error abstraction
+# ---------------------------------------------------------------------------
+
+if MCP_VERSION >= 2:
+    from mcp.shared.exceptions import (
+        MCPError as McpErrorClass,  # type: ignore[assignment]
+    )
+
+    def make_mcp_error(code: int, message: str) -> Exception:
+        """Create an MCP error (v2 constructor)."""
+        return McpErrorClass(code, message)  # type: ignore[call-arg]
+
+else:
+    from mcp.shared.exceptions import (
+        McpError as McpErrorClass,  # type: ignore[assignment,no-redef]
+    )
+    from mcp.types import ErrorData as _ErrorData
+
+    def make_mcp_error(code: int, message: str) -> Exception:  # type: ignore[misc]
+        """Create an MCP error (v1 constructor wraps ErrorData)."""
+        return McpErrorClass(_ErrorData(code=code, message=message))
+
+
+# ---------------------------------------------------------------------------
+# Request context bridge
+# ---------------------------------------------------------------------------
+
+# In v2 the lowlevel handler receives ``ctx`` as a parameter; we stash it
+# here so that ``get_mcp_session_info()`` can retrieve it the same way
+# v1's ``request_ctx`` contextvar works.
+_v2_request_ctx: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "_v2_request_ctx", default=None
+)
+
+
+def get_mcp_session_info() -> tuple[Any, Any | None] | None:
+    """Return ``(mcp_session, starlette_request | None)`` for the current request.
+
+    Works transparently with both v1 (reads ``request_ctx`` contextvar)
+    and v2 (reads the ctx we stashed from the handler parameter).
+
+    Returns:
+        A tuple of (session, request) or ``None`` when called outside
+        an MCP request context.
+    """
+    if MCP_VERSION >= 2:
+        ctx = _v2_request_ctx.get(None)
+        if ctx is None:
+            return None
+        session = ctx.session
+        request = getattr(ctx, "request", None)
+        return session, request
+    else:
+        try:
+            from mcp.server.lowlevel.server import request_ctx
+        except ImportError:
+            return None
+        mcp_ctx = request_ctx.get(None)
+        if mcp_ctx is None:
+            return None
+        session = mcp_ctx.session
+        request = getattr(mcp_ctx, "request", None)
+        return session, request
+
+
+# ---------------------------------------------------------------------------
+# Server creation
+# ---------------------------------------------------------------------------
+
+# Handler type aliases (our uniform internal signatures)
+ListToolsHandler = Callable[[], Coroutine[Any, Any, "list[MCPTool]"]]
+CallToolHandler = Callable[
+    [str, dict[str, Any]], Coroutine[Any, Any, "list[TextContent]"]
+]
+
+
+def create_mcp_server(
+    name: str,
+    *,
+    list_tools_handler: ListToolsHandler,
+    call_tool_handler: CallToolHandler,
+) -> Server:
+    """Create an MCP lowlevel Server with handlers registered.
+
+    Our handlers use a stable internal signature; this function adapts
+    them to whatever the installed SDK version expects.
+
+    Args:
+        name: Server name for MCP identification.
+        list_tools_handler: ``async () -> list[Tool]``
+        call_tool_handler: ``async (name, arguments) -> list[TextContent]``
+
+    Returns:
+        A configured ``mcp.server.lowlevel.Server``.
+    """
+    if MCP_VERSION >= 2:
+        return _create_server_v2(name, list_tools_handler, call_tool_handler)
+    else:
+        return _create_server_v1(name, list_tools_handler, call_tool_handler)
+
+
+def _create_server_v1(
+    name: str,
+    list_tools_handler: ListToolsHandler,
+    call_tool_handler: CallToolHandler,
+) -> Server:
+    from mcp.server.lowlevel import Server
+
+    server = Server(name)
+
+    @server.list_tools()
+    async def _list_tools() -> list:
+        return await list_tools_handler()
+
+    @server.call_tool(validate_input=False)
+    async def _call_tool(tool_name: str, arguments: dict) -> list:
+        return await call_tool_handler(tool_name, arguments)
+
+    return server
+
+
+def _create_server_v2(
+    name: str,
+    list_tools_handler: ListToolsHandler,
+    call_tool_handler: CallToolHandler,
+) -> Server:
+    from mcp.server.lowlevel import Server
+    from mcp.types import CallToolResult, ListToolsResult
+
+    async def on_list_tools(ctx: Any, params: Any) -> Any:
+        tools = await list_tools_handler()
+        return ListToolsResult(tools=tools)
+
+    async def on_call_tool(ctx: Any, params: Any) -> Any:
+        token = _v2_request_ctx.set(ctx)
+        try:
+            tool_name = params.name
+            arguments = params.arguments or {}
+            content = await call_tool_handler(tool_name, arguments)
+            return CallToolResult(content=content, is_error=False)  # type: ignore[call-arg]
+        except McpErrorClass:
+            raise
+        except Exception:
+            return CallToolResult(  # type: ignore[call-arg]
+                content=[],
+                is_error=True,
+            )
+        finally:
+            _v2_request_ctx.reset(token)
+
+    return Server(  # type: ignore[call-arg]
+        name,
+        on_list_tools=on_list_tools,
+        on_call_tool=on_call_tool,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field accessor
+# ---------------------------------------------------------------------------
+
+
+def get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) -> Any:
+    """Access a field that may be snake_case (v2) or camelCase (v1).
+
+    Tries snake_case first (v2 attribute access), then camelCase (v1).
+    """
+    val = getattr(obj, snake_name, None)
+    if val is not None:
+        return val
+    return getattr(obj, camel_name, default)
+
+
+# ---------------------------------------------------------------------------
+# Test helper
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def create_test_client(server: Server):
+    """Create an in-memory test client connected to a server.
+
+    v1: ``create_connected_server_and_client_session``
+    v2: ``mcp.client.Client``
+
+    Yields:
+        A session/client object with ``list_tools()`` and ``call_tool()``
+        methods.
+    """
+    if MCP_VERSION >= 2:
+        from mcp.client import Client
+
+        async with Client(server) as client:
+            yield client
+    else:
+        from mcp.shared.memory import (
+            create_connected_server_and_client_session as _create,
+        )
+
+        async with _create(server) as session:
+            yield session
+
+
+__all__ = [
+    "MCP_VERSION",
+    "McpErrorClass",
+    "make_mcp_error",
+    "get_mcp_session_info",
+    "create_mcp_server",
+    "get_field",
+    "create_test_client",
+]

--- a/src/toolregistry_server/adapters/mcp/_compat.py
+++ b/src/toolregistry_server/adapters/mcp/_compat.py
@@ -164,11 +164,15 @@ def _create_server_v2(
     from mcp.server.lowlevel import Server
     from mcp.types import CallToolResult, ListToolsResult
 
+    # list_tools does not set _v2_request_ctx because list_tools
+    # handlers don't need session context.
     async def on_list_tools(ctx: Any, params: Any) -> Any:
         tools = await list_tools_handler()
         return ListToolsResult(tools=tools)
 
     async def on_call_tool(ctx: Any, params: Any) -> Any:
+        from mcp.types import TextContent
+
         token = _v2_request_ctx.set(ctx)
         try:
             tool_name = params.name
@@ -177,9 +181,9 @@ def _create_server_v2(
             return CallToolResult(content=content, is_error=False)  # type: ignore[call-arg]
         except McpErrorClass:
             raise
-        except Exception:
+        except Exception as e:
             return CallToolResult(  # type: ignore[call-arg]
-                content=[],
+                content=[TextContent(type="text", text=str(e))],
                 is_error=True,
             )
         finally:
@@ -197,13 +201,17 @@ def _create_server_v2(
 # ---------------------------------------------------------------------------
 
 
+_MISSING = object()
+
+
 def get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) -> Any:
     """Access a field that may be snake_case (v2) or camelCase (v1).
 
-    Tries snake_case first (v2 attribute access), then camelCase (v1).
+    Uses a sentinel so that legitimate ``None`` values (e.g. optional
+    ``mime_type``) are not confused with "attribute missing".
     """
-    val = getattr(obj, snake_name, None)
-    if val is not None:
+    val = getattr(obj, snake_name, _MISSING)
+    if val is not _MISSING:
         return val
     return getattr(obj, camel_name, default)
 

--- a/src/toolregistry_server/adapters/mcp/adapter.py
+++ b/src/toolregistry_server/adapters/mcp/adapter.py
@@ -31,9 +31,9 @@ logger = get_logger()
 def _get_session_context(session_mgr: "SessionManager") -> SessionContext | None:
     """Extract or create a SessionContext from the current MCP request.
 
-    Reads the MCP SDK's ``request_ctx`` contextvar to obtain the active
-    ``ServerSession`` and optional Starlette ``Request``, then delegates
-    to *session_mgr* for deduplication and lifecycle management.
+    Uses the compat layer to read the active MCP request context
+    (works with both mcp v1 and v2), then delegates to *session_mgr*
+    for deduplication and lifecycle management.
 
     Args:
         session_mgr: The SessionManager that owns session state.
@@ -42,25 +42,19 @@ def _get_session_context(session_mgr: "SessionManager") -> SessionContext | None
         A :class:`SessionContext`, or ``None`` when called outside an
         MCP request context (should not happen in practice).
     """
-    try:
-        from mcp.server.lowlevel.server import request_ctx
-    except ImportError:
+    from ._compat import get_mcp_session_info
+
+    info = get_mcp_session_info()
+    if info is None:
         return None
 
-    mcp_ctx = request_ctx.get(None)
-    if mcp_ctx is None:
-        return None
-
-    mcp_session = mcp_ctx.session
+    mcp_session, request = info
     session_key = id(mcp_session)
 
     def _factory() -> SessionContext:
-        # Determine transport type from the request object
-        request = getattr(mcp_ctx, "request", None)
         if request is None:
             transport = "stdio"
         else:
-            # Starlette Request — check for streamable-http header
             headers = getattr(request, "headers", {})
             transport = "streamable-http" if headers.get("mcp-session-id") else "sse"
 
@@ -70,8 +64,6 @@ def _get_session_context(session_mgr: "SessionManager") -> SessionContext | None
         )
 
     ctx = session_mgr.get_or_create(session_key, _factory)
-
-    # Register weak-reference finalizer for automatic cleanup
     session_mgr.register_finalizer(mcp_session, session_key)
 
     return ctx
@@ -177,20 +169,18 @@ def route_table_to_mcp_server(
         ImportError: If MCP SDK is not installed.
     """
     try:
-        from mcp.server.lowlevel import Server
-        from mcp.shared.exceptions import McpError
-        from mcp.types import INTERNAL_ERROR, ErrorData, TextContent
+        from mcp.types import INTERNAL_ERROR, TextContent
         from mcp.types import Tool as MCPTool
+
+        from ._compat import McpErrorClass, create_mcp_server, make_mcp_error
     except ImportError as e:
         raise ImportError(
             "MCP SDK is required for MCP support. "
             "Install with: pip install toolregistry-server[mcp]"
         ) from e
 
-    server = Server(name)
     session_mgr = SessionManager()
 
-    @server.list_tools()
     async def handle_list_tools() -> list[MCPTool]:
         """Return MCP tool definitions for non-deferred enabled tools.
 
@@ -209,40 +199,28 @@ def route_table_to_mcp_server(
         logger.debug(f"list_tools: returning {len(tools)} enabled tools")
         return tools
 
-    @server.call_tool(validate_input=False)
-    async def handle_call_tool(name: str, arguments: dict) -> list[TextContent]:
+    async def handle_call_tool(tool_name: str, arguments: dict) -> list[TextContent]:
         """Execute a tool by name with the given arguments.
 
         Args:
-            name: The tool name to invoke.
+            tool_name: The tool name to invoke.
             arguments: The input arguments for the tool.
 
         Returns:
             A list containing a single TextContent with the result.
 
         Raises:
-            McpError: If the tool is disabled or not found.
+            McpErrorClass: If the tool is disabled or not found.
         """
-        # Get the route entry
-        route = route_table.get_route(name)
+        route = route_table.get_route(tool_name)
 
-        # Check if tool exists
         if route is None:
-            raise McpError(
-                ErrorData(
-                    code=INTERNAL_ERROR,
-                    message=f"Tool '{name}' not found",
-                )
-            )
+            raise make_mcp_error(INTERNAL_ERROR, f"Tool '{tool_name}' not found")
 
-        # Check if tool is disabled
         if not route.enabled:
             reason = route.disable_reason or "unknown reason"
-            raise McpError(
-                ErrorData(
-                    code=INTERNAL_ERROR,
-                    message=f"Tool '{name}' is disabled: {reason}",
-                )
+            raise make_mcp_error(
+                INTERNAL_ERROR, f"Tool '{tool_name}' is disabled: {reason}"
             )
 
         # --- Session context ---
@@ -254,22 +232,23 @@ def route_table_to_mcp_server(
         try:
             result = await _execute_tool(route, arguments, session_ctx, session_mgr)
             text = _serialize_result(result)
-            logger.debug(f"call_tool '{name}': success")
+            logger.debug(f"call_tool '{tool_name}': success")
             return [TextContent(type="text", text=text)]
 
-        except McpError:
+        except McpErrorClass:
             raise
         except Exception as e:
-            logger.warning(f"call_tool '{name}': error - {e}")
-            raise McpError(
-                ErrorData(
-                    code=INTERNAL_ERROR,
-                    message=str(e),
-                )
-            ) from e
+            logger.warning(f"call_tool '{tool_name}': error - {e}")
+            raise make_mcp_error(INTERNAL_ERROR, str(e)) from e
         finally:
             if token is not None:
                 session_context_var.reset(token)
+
+    server = create_mcp_server(
+        name,
+        list_tools_handler=handle_list_tools,
+        call_tool_handler=handle_call_tool,
+    )
 
     logger.info(
         f"MCP server '{name}' created with {len(route_table.list_routes())} "

--- a/src/toolregistry_server/adapters/mcp/adapter.py
+++ b/src/toolregistry_server/adapters/mcp/adapter.py
@@ -42,14 +42,13 @@ def _get_session_context(session_mgr: "SessionManager") -> SessionContext | None
         A :class:`SessionContext`, or ``None`` when called outside an
         MCP request context (should not happen in practice).
     """
-    from ._compat import get_mcp_session_info
+    from ._compat import _STDIO_SESSION_KEY, get_mcp_session_info
 
     info = get_mcp_session_info()
     if info is None:
         return None
 
-    mcp_session, request = info
-    session_key = id(mcp_session)
+    mcp_session, request, session_key = info
 
     def _factory() -> SessionContext:
         if request is None:
@@ -64,7 +63,12 @@ def _get_session_context(session_mgr: "SessionManager") -> SessionContext | None
         )
 
     ctx = session_mgr.get_or_create(session_key, _factory)
-    session_mgr.register_finalizer(mcp_session, session_key)
+
+    # In v2 direct/stdio transport, ctx.session is a new object per call,
+    # so a weak-ref finalizer would GC the session between calls. Only
+    # register when the session object is stable (v1, or v2 HTTP).
+    if session_key is not _STDIO_SESSION_KEY:
+        session_mgr.register_finalizer(mcp_session, session_key)
 
     return ctx
 
@@ -170,9 +174,13 @@ def route_table_to_mcp_server(
     """
     try:
         from mcp.types import INTERNAL_ERROR, TextContent
-        from mcp.types import Tool as MCPTool
 
-        from ._compat import McpErrorClass, create_mcp_server, make_mcp_error
+        from ._compat import (
+            McpErrorClass,
+            create_mcp_server,
+            make_mcp_error,
+            make_mcp_tool,
+        )
     except ImportError as e:
         raise ImportError(
             "MCP SDK is required for MCP support. "
@@ -181,19 +189,19 @@ def route_table_to_mcp_server(
 
     session_mgr = SessionManager()
 
-    async def handle_list_tools() -> list[MCPTool]:
+    async def handle_list_tools() -> list:
         """Return MCP tool definitions for non-deferred enabled tools.
 
         Deferred tools are excluded from the initial listing so that LLMs
         discover them via discover_tools.
         """
-        tools: list[MCPTool] = []
+        tools: list = []
         for route in route_table.list_routes(enabled_only=True, include_deferred=False):
             tools.append(
-                MCPTool(
+                make_mcp_tool(
                     name=route.tool_name,
                     description=route.description or "",
-                    inputSchema=normalize_parameters_schema(route.parameters_schema),
+                    schema=normalize_parameters_schema(route.parameters_schema),
                 )
             )
         logger.debug(f"list_tools: returning {len(tools)} enabled tools")

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,6 +1,6 @@
 """Tests for the MCP adapter that bridges RouteTable to MCP Server.
 
-Uses the MCP SDK's in-memory transport (create_connected_server_and_client_session)
+Uses the MCP SDK's in-memory transport (create_test_client)
 for end-to-end testing of list_tools and call_tool handlers.
 """
 
@@ -9,11 +9,11 @@ from unittest.mock import MagicMock
 
 import pytest
 from mcp.server.lowlevel import Server
-from mcp.shared.memory import create_connected_server_and_client_session
 from toolregistry.tool import Tool
 
 from toolregistry_server import RouteEntry, RouteTable
 from toolregistry_server.adapters.mcp import route_table_to_mcp_server
+from toolregistry_server.adapters.mcp._compat import create_test_client, get_field
 
 # ---------------------------------------------------------------------------
 # Test helper functions
@@ -206,7 +206,7 @@ class TestListTools:
     ) -> None:
         """Verify list_tools returns all enabled tools from the route table."""
         server = route_table_to_mcp_server(route_table_with_tools)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.list_tools()
             tool_names = {t.name for t in result.tools}
             assert tool_names == {"add", "multiply"}
@@ -217,7 +217,7 @@ class TestListTools:
     ) -> None:
         """Verify tool name and description are correctly mapped."""
         server = route_table_to_mcp_server(route_table_with_tools)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.list_tools()
             tools_by_name = {t.name: t for t in result.tools}
 
@@ -233,11 +233,11 @@ class TestListTools:
     ) -> None:
         """Verify inputSchema contains correct parameter definitions."""
         server = route_table_to_mcp_server(route_table_with_tools)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.list_tools()
             tools_by_name = {t.name: t for t in result.tools}
 
-            schema = tools_by_name["add"].inputSchema
+            schema = get_field(tools_by_name["add"], "input_schema", "inputSchema")
             assert schema["type"] == "object"
             assert "a" in schema["properties"]
             assert "b" in schema["properties"]
@@ -264,9 +264,12 @@ class TestListTools:
 
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.list_tools()
-            assert result.tools[0].inputSchema == {"type": "object", "properties": {}}
+            assert get_field(result.tools[0], "input_schema", "inputSchema") == {
+                "type": "object",
+                "properties": {},
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -311,7 +314,7 @@ class TestEnableDisable:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             # Initially both tools are listed
             result = await client.list_tools()
             assert {t.name for t in result.tools} == {"add", "multiply"}
@@ -354,7 +357,7 @@ class TestEnableDisable:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             # Disable then re-enable
             route = route_table.get_route("add")
             assert route is not None
@@ -406,9 +409,9 @@ class TestCallTool:
     async def test_call_enabled_tool(self, route_table_with_tools: RouteTable) -> None:
         """Calling an enabled tool should return the correct result."""
         server = route_table_to_mcp_server(route_table_with_tools)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("add", {"a": 3, "b": 4})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert len(result.content) == 1
             assert result.content[0].text == "7"
 
@@ -433,9 +436,9 @@ class TestCallTool:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("add", {"a": 1, "b": 2})
-            assert result.isError is True
+            assert get_field(result, "is_error", "isError") is True
             assert "disabled" in result.content[0].text.lower()
             assert "maintenance" in result.content[0].text
 
@@ -445,9 +448,9 @@ class TestCallTool:
     ) -> None:
         """Calling a non-existent tool should return isError=True."""
         server = route_table_to_mcp_server(route_table_with_tools)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("nonexistent", {})
-            assert result.isError is True
+            assert get_field(result, "is_error", "isError") is True
             assert "not found" in result.content[0].text.lower()
 
 
@@ -476,9 +479,9 @@ class TestSyncAsyncTools:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("add", {"a": 10, "b": 20})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "30"
 
     @pytest.mark.asyncio
@@ -498,9 +501,9 @@ class TestSyncAsyncTools:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("async_add", {"a": 5, "b": 7})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "12"
 
     @pytest.mark.asyncio
@@ -531,7 +534,7 @@ class TestSyncAsyncTools:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             # Verify both are listed
             tools_result = await client.list_tools()
             tool_names = {t.name for t in tools_result.tools}
@@ -571,9 +574,9 @@ class TestResultSerialization:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("get_info", {})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             parsed = json.loads(result.content[0].text)
             assert parsed == {"status": "ok", "count": 42}
 
@@ -594,9 +597,9 @@ class TestResultSerialization:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("greet", {"name": "World"})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "Hello, World!"
 
     @pytest.mark.asyncio
@@ -616,9 +619,9 @@ class TestResultSerialization:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("get_answer", {})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "42"
 
     @pytest.mark.asyncio
@@ -638,9 +641,9 @@ class TestResultSerialization:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("get_pi", {})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "3.14159"
 
     @pytest.mark.asyncio
@@ -665,9 +668,9 @@ class TestResultSerialization:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("get_items", {})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             parsed = json.loads(result.content[0].text)
             assert parsed == [1, "two", 3.0]
 
@@ -699,9 +702,9 @@ class TestExceptionHandling:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("failing_tool", {})
-            assert result.isError is True
+            assert get_field(result, "is_error", "isError") is True
             assert "intentional error for testing" in result.content[0].text
 
 
@@ -747,9 +750,9 @@ class TestParameterValidation:
     ) -> None:
         """String arguments should be coerced to int when parameters_model is present."""
         server = route_table_to_mcp_server(route_table_with_validated_tool)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("add", {"a": "3", "b": "4"})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "7"
 
     @pytest.mark.asyncio
@@ -758,12 +761,12 @@ class TestParameterValidation:
     ) -> None:
         """String values for optional int/float params should be coerced."""
         server = route_table_to_mcp_server(route_table_with_search_tool)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool(
                 "search",
                 {"query": "test", "max_results": "8", "timeout": "15.5"},
             )
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             text = result.content[0].text
             assert "max_results=8(int)" in text
             assert "timeout=15.5(float)" in text
@@ -774,9 +777,9 @@ class TestParameterValidation:
     ) -> None:
         """Default values should be used when optional params are omitted."""
         server = route_table_to_mcp_server(route_table_with_search_tool)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("search", {"query": "hello"})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             text = result.content[0].text
             assert "max_results=5(int)" in text
             assert "timeout=10.0(float)" in text
@@ -787,9 +790,9 @@ class TestParameterValidation:
     ) -> None:
         """Correctly typed arguments should pass through without issue."""
         server = route_table_to_mcp_server(route_table_with_validated_tool)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("add", {"a": 10, "b": 20})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "30"
 
     @pytest.mark.asyncio
@@ -798,12 +801,12 @@ class TestParameterValidation:
     ) -> None:
         """All params as strings (Codex-like behavior) should be coerced."""
         server = route_table_to_mcp_server(route_table_with_search_tool)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool(
                 "search",
                 {"query": "test query", "max_results": "3", "timeout": "5.0"},
             )
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             text = result.content[0].text
             assert "query=test query" in text
             assert "max_results=3(int)" in text
@@ -815,9 +818,9 @@ class TestParameterValidation:
     ) -> None:
         """Non-numeric string for int param should return an error."""
         server = route_table_to_mcp_server(route_table_with_validated_tool)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("add", {"a": "abc", "b": "4"})
-            assert result.isError is True
+            assert get_field(result, "is_error", "isError") is True
 
     @pytest.mark.asyncio
     async def test_bool_param_coerced_from_string(
@@ -842,9 +845,9 @@ class TestParameterValidation:
         route_table = RouteTable(mock_registry)
 
         server = route_table_to_mcp_server(route_table)
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool(
                 "check", {"query": "test", "verbose": "true"}
             )
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert "verbose=True(bool)" in result.content[0].text

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -12,7 +12,11 @@ import pytest
 from toolregistry.tool import Tool
 
 from toolregistry_server import RouteTable
-from toolregistry_server.adapters.mcp._compat import create_test_client, get_field
+from toolregistry_server.adapters.mcp._compat import (
+    MCP_VERSION,
+    create_test_client,
+    get_field,
+)
 from toolregistry_server.adapters.mcp.adapter import route_table_to_mcp_server
 from toolregistry_server.session import SessionContext
 
@@ -206,6 +210,10 @@ class TestSessionStability:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    MCP_VERSION >= 2,
+    reason="v2 direct/in-memory transport has no per-client session identity",
+)
 class TestSessionIsolation:
     """Different MCP sessions should get independent SessionContexts."""
 

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from mcp.shared.memory import create_connected_server_and_client_session
 from toolregistry.tool import Tool
 
 from toolregistry_server import RouteTable
+from toolregistry_server.adapters.mcp._compat import create_test_client, get_field
 from toolregistry_server.adapters.mcp.adapter import route_table_to_mcp_server
 from toolregistry_server.session import SessionContext
 
@@ -106,9 +106,9 @@ class TestBackwardCompatibility:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("plain_add", {"a": 3, "b": 4})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             assert result.content[0].text == "7"
 
 
@@ -129,9 +129,9 @@ class TestSessionInjection:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("session_echo", {"x": 42})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             text = result.content[0].text
             assert "x=42" in text
             assert "session=" in text
@@ -148,9 +148,9 @@ class TestSessionInjection:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             result = await client.call_tool("async_session_echo", {"x": 7})
-            assert result.isError is False
+            assert get_field(result, "is_error", "isError") is False
             text = result.content[0].text
             assert "async x=7" in text
             assert "session=" in text
@@ -173,7 +173,7 @@ class TestSessionStability:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             r1 = await client.call_tool("session_echo", {"x": 1})
             r2 = await client.call_tool("session_echo", {"x": 2})
 
@@ -190,7 +190,7 @@ class TestSessionStability:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             r1 = await client.call_tool("session_counter", {})
             assert r1.content[0].text == "count=1"
 
@@ -220,11 +220,11 @@ class TestSessionIsolation:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client1:
+        async with create_test_client(server) as client1:
             r1 = await client1.call_tool("session_echo", {"x": 1})
             sid1 = r1.content[0].text.split("session=")[1]
 
-        async with create_connected_server_and_client_session(server) as client2:
+        async with create_test_client(server) as client2:
             r2 = await client2.call_tool("session_echo", {"x": 2})
             sid2 = r2.content[0].text.split("session=")[1]
 
@@ -240,13 +240,13 @@ class TestSessionIsolation:
         server = route_table_to_mcp_server(route_table)
 
         # First session counts to 2
-        async with create_connected_server_and_client_session(server) as client1:
+        async with create_test_client(server) as client1:
             await client1.call_tool("session_counter", {})
             r = await client1.call_tool("session_counter", {})
             assert r.content[0].text == "count=2"
 
         # Second session starts fresh at 1
-        async with create_connected_server_and_client_session(server) as client2:
+        async with create_test_client(server) as client2:
             r = await client2.call_tool("session_counter", {})
             assert r.content[0].text == "count=1"
 
@@ -272,14 +272,14 @@ class TestMixedTools:
         route_table = RouteTable(mock_registry)
         server = route_table_to_mcp_server(route_table)
 
-        async with create_connected_server_and_client_session(server) as client:
+        async with create_test_client(server) as client:
             # Plain tool works
             r1 = await client.call_tool("plain_add", {"a": 5, "b": 3})
-            assert r1.isError is False
+            assert get_field(r1, "is_error", "isError") is False
             assert r1.content[0].text == "8"
 
             # Session tool works
             r2 = await client.call_tool("session_echo", {"x": 10})
-            assert r2.isError is False
+            assert get_field(r2, "is_error", "isError") is False
             assert "x=10" in r2.content[0].text
             assert "session=" in r2.content[0].text


### PR DESCRIPTION
## Summary

- Introduce `adapters/mcp/_compat.py` that abstracts the breaking changes between mcp SDK v1.x and v2.x
- Refactor `adapter.py` to import only through `_compat`, eliminating direct `mcp.*` imports for version-sensitive APIs
- Update tests to use compat accessors (`get_field`, `create_test_client`) instead of v1-only APIs
- Correct minimum mcp pin from `>=1.8.0` to `>=1.17.0` (pre-existing bug: `build_resource_metadata_url` in Bearer auth path requires 1.17+)

This is internal refactoring + pin correction. The actual pin widening to `mcp>=1.17,<3` is a coordinated follow-up after the core side (Oaklight/ToolRegistry#232) is also merged.

**Note:** Server minimum (`>=1.17.0`) is lower than core's (`>=1.24.0`) because the server doesn't use `streamable_http_client` with `http_client=` kwarg.

### What `_compat.py` abstracts

| Concern | v1 | v2 |
|---|---|---|
| Error class | `McpError(ErrorData(code, msg))` | `MCPError(code, msg)` |
| Server creation | `Server(name)` + `@server.list_tools()` decorator | `Server(name, on_list_tools=...)` constructor kwarg |
| Handler signature | `() -> list[Tool]` / `(name, args) -> list[TextContent]` | `(ctx, params) -> ListToolsResult` / `CallToolResult` |
| Request context | `request_ctx` contextvar | `ctx` handler parameter |
| Test client | `create_connected_server_and_client_session` | `mcp.client.Client` |
| Field names | `result.isError`, `tool.inputSchema` | `result.is_error`, `tool.input_schema` |

### Multi-version test results

| mcp version | Server (47 tests) | Status |
|---|---|---|
| v1.24.0 | 47 passed | :white_check_mark: |
| v1.26.0 | 47 passed | :white_check_mark: |
| v1.29.0 | 47 passed | :white_check_mark: |

### Review feedback addressed

- Sentinel pattern in `get_field()` for nullable fields (all reviewers)
- Error message in v2 `on_call_tool` safety-net fallback (Milo, Elena, Clementine)
- Comment on `on_list_tools` not setting `_v2_request_ctx` (Milo, Clementine)

Closes #55